### PR TITLE
Ensure JSON data is read in with encoding UTF-8

### DIFF
--- a/templates/autolabel_tma_cores.ipynb
+++ b/templates/autolabel_tma_cores.ipynb
@@ -112,7 +112,7 @@
     ")\n",
     "\n",
     "# save the automatically-named TMA FOVs to centroids mapping\n",
-    "with open(auto_fov_names_path, 'w') as afrp:\n",
+    "with open(auto_fov_names_path, 'w', encoding='utf-8') as afrp:\n",
     "    json.dump(auto_fov_regions, afrp)"
    ]
   },
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "# load the user-defined set of FOVs in\n",
-    "with open(manual_run_path, 'r') as mfop:\n",
+    "with open(manual_run_path, 'r', encoding='utf-8') as mfop:\n",
     "    manual_fov_regions = json.load(mfop)"
    ]
   },
@@ -239,7 +239,7 @@
    "outputs": [],
    "source": [
     "# load the mapping saved by the interactive visualization in\n",
-    "with open(mapping_path, 'r') as mp:\n",
+    "with open(mapping_path, 'r', encoding='utf-8') as mp:\n",
     "    mapping = json.load(mp)"
    ]
   },
@@ -284,14 +284,14 @@
    "outputs": [],
    "source": [
     "# save remapped_fov_regions\n",
-    "with open(remapped_fov_path, 'w') as rtp:\n",
+    "with open(remapped_fov_path, 'w', encoding='utf-8') as rtp:\n",
     "    json.dump(remapped_fov_regions, rtp)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -305,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -208,7 +208,7 @@ def set_tiled_region_params(region_corners_path):
         )
 
     # read in the region corners data
-    with open(region_corners_path, 'r') as flf:
+    with open(region_corners_path, 'r', encoding='utf-8') as flf:
         tiled_region_corners = json.load(flf)
 
     # define the parameter dict to return
@@ -366,7 +366,7 @@ def generate_tiled_region_fov_list(tiling_params, moly_path):
         raise FileNotFoundError("Moly point file %s does not exist" % moly_path)
 
     # read in the moly point data
-    with open(moly_path, 'r') as mpf:
+    with open(moly_path, 'r', encoding='utf-8') as mpf:
         moly_point = json.load(mpf)
 
     # define the fov_regions dict
@@ -513,7 +513,7 @@ def generate_tma_fov_list(tma_corners_path, num_fov_x, num_fov_y):
         raise ValueError("Number of FOVs along y-axis must be at least 3")
 
     # read in tma_corners_path
-    with open(tma_corners_path, 'r') as flf:
+    with open(tma_corners_path, 'r', encoding='utf-8') as flf:
         tma_corners = json.load(flf)
 
     # a TMA can only be defined by four FOVs, one for each corner
@@ -907,7 +907,7 @@ def write_manual_to_auto_map(manual_to_auto_map, save_ann, mapping_path):
     """
 
     # save the mapping
-    with open(mapping_path, 'w') as mp:
+    with open(mapping_path, 'w', encoding='utf-8') as mp:
         json.dump(manual_to_auto_map, mp)
 
     # remove the save annotation if it already exists
@@ -1139,7 +1139,7 @@ def remap_and_reorder_fovs(manual_fov_regions, manual_to_auto_map,
         raise FileNotFoundError("Moly point %s does not exist" % moly_path)
 
     # load the Moly point in
-    with open(moly_path, 'r') as mp:
+    with open(moly_path, 'r', encoding='utf-8') as mp:
         moly_point = json.load(mp)
 
     # error check: moly_interval cannot be less than or equal to 0 if moly_insert is True


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #25. The Windows CAC uses a different default encoding when reading in JSON data. This present a problem for the Moly points in particular, which contain a unique µ symbol which gets garbled on Windows, causing the run files to become malformed. We need to override the default encoding on Windows so this character can be represented correctly.

**How did you implement your changes**

Add an explicit `encoding='utf-8'` line to every `open` call that requires `json.load` or `json.dump`.
