### PR TITLE
Add notebook to change co-registration parameters in settings.py

### DIFF
--- a/templates/update_coregistration_params.ipynb
+++ b/templates/update_coregistration_params.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ec35cb18-c771-48e6-859f-e10e074545d6",
+   "metadata": {},
+   "source": [
+    "# Update coregistration constants"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edb13b4a-9589-4c2d-814c-0cae835cc255",
+   "metadata": {},
+   "source": [
+    "For tiling purposes, we use a default set of constants to coregister FOV coordinates onto the slide. However, depending on the positioning of your slide on the commercial instrument, you may need to adjust these.\n",
+    "\n",
+    "Coregistration is done using the fiducial markers on the slide. Please provide the stage coordinate and corresponding optical pixel coordinate values for the top 3 pairs in this notebook.\n",
+    "\n",
+    "To retrieve the stage coordinate and pixel coordinate values, open the slide on the CAC and open the developer console. Set `logger.level = 4`, then click on one of the fiducials. The stage coordinates will be printed above the slide, and the corresponding pixel coordinates will be printed in the console."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0d1bdc51-fe32-4a92-a5bb-f7d53628458c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import os\n",
+    "from sklearn.linear_model import LinearRegression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44bf4948-eebe-43a9-8e0e-a993dc8e726b",
+   "metadata": {},
+   "source": [
+    "### Set stage and pixel coordinates for the top 3 fiducial pairs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "019e24b7-8793-4415-9983-103831b37da3",
+   "metadata": {},
+   "source": [
+    "TODO: prompt the user instead?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "42e854fa-4e04-40e3-97a9-a51ded65684a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# top pair\n",
+    "top_pair_left_stage = (0.1, 49)\n",
+    "top_pair_left_pixel = (405, 410)\n",
+    "top_pair_right_stage = (22, 48)\n",
+    "top_pair_right_pixel = (723, 414)\n",
+    "\n",
+    "# middle pair\n",
+    "middle_pair_left_stage = (0.2, 33)\n",
+    "middle_pair_left_pixel = (401, 641)\n",
+    "middle_pair_right_stage = (22, 32)\n",
+    "middle_pair_right_pixel = (721, 644)\n",
+    "\n",
+    "# bottom pair\n",
+    "bottom_pair_left_stage = (0.3, 18)\n",
+    "bottom_pair_left_pixel = (403, 875)\n",
+    "bottom_pair_right_stage = (22, 17)\n",
+    "bottom_pair_right_pixel = (722, 878)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce74c91b-86ef-4569-87ac-b8553ecb23bc",
+   "metadata": {},
+   "source": [
+    "### Regress stage to pixel coordinates (separately for x- and y-coordinate values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f65a7f58-e45d-44e9-85ca-b5168b996045",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the lists for x-coordinate stage and corresponding pixel values for regression\n",
+    "x_stage = np.array([\n",
+    "    top_pair_left_stage[0], top_pair_right_stage[0],\n",
+    "    middle_pair_left_stage[0], middle_pair_right_stage[0],\n",
+    "    bottom_pair_left_stage[0], bottom_pair_right_stage[0]\n",
+    "])\n",
+    "x_pixel = np.array([\n",
+    "    top_pair_left_pixel[0], top_pair_right_pixel[0],\n",
+    "    middle_pair_left_pixel[0], middle_pair_right_pixel[0],\n",
+    "    bottom_pair_left_pixel[0], bottom_pair_right_pixel[0]\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0c581d43-c06b-409e-b149-9a43892eefcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the lists for y-coordinate stage and corresponding pixel values for regression\n",
+    "y_stage = np.array([\n",
+    "    top_pair_left_stage[1], top_pair_right_stage[1],\n",
+    "    middle_pair_left_stage[1], middle_pair_right_stage[1],\n",
+    "    bottom_pair_left_stage[1], bottom_pair_right_stage[1]\n",
+    "])\n",
+    "y_pixel = np.array([\n",
+    "    top_pair_left_pixel[1], top_pair_right_pixel[1],\n",
+    "    middle_pair_left_pixel[1], middle_pair_right_pixel[1],\n",
+    "    bottom_pair_left_pixel[1], bottom_pair_right_pixel[1]\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c8163ba9-dcb2-4545-ad94-9614cd4dc291",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate regression parameters for x stage to pixel\n",
+    "x_regression = LinearRegression().fit(\n",
+    "    np.reshape(x_stage, (-1, 1)),\n",
+    "    np.reshape(x_pixel, (-1, 1))\n",
+    ")\n",
+    "\n",
+    "x_multiplier = x_regression.coef_[0][0]\n",
+    "x_offset = x_regression.intercept_ / x_multiplier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "04987a93-ff5b-4955-af77-e4acd7e9119f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# generate regression parameters for y stage to pixel\n",
+    "y_regression = LinearRegression().fit(\n",
+    "    np.reshape(y_stage, (-1, 1)),\n",
+    "    np.reshape(y_pixel, (-1, 1))\n",
+    ")\n",
+    "\n",
+    "y_multiplier = y_regression.coef_[0][0]\n",
+    "y_offset = y_regression.intercept_ / y_multiplier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7df88849-a7ba-400c-92bd-88e165a5b515",
+   "metadata": {},
+   "source": [
+    "### Change global fiducial settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "76415053-abf7-4c3d-b5b5-524bcc37b1fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# append new constant values to settings.py\n",
+    "with open(os.path.join('../toffy/settings.py'), 'a') as fw:\n",
+    "    fw.write('STAGE_TO_PIXEL_X_MULTIPLIER = %f\\n' % x_multiplier)\n",
+    "    fw.write('STAGE_TO_PIXEL_X_OFFSET = %f\\n' % x_offset)\n",
+    "    fw.write('STAGE_TO_PIXEL_Y_MULTIPLIER = %f\\n' % y_multiplier)\n",
+    "    fw.write('STAGE_TO_PIXEL_Y_OFFSET = %f\\n' % y_offset)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**What is the purpose of this PR?**

Currently, we have fixed constants for co-registering coordinates from `fovCenterMicrons` in each FOV of a spec file to the slide for visualization. However, for the stage coordinates to optical pixels conversion, this will fail if the slide position gets moved on the commercial instrument, causing the fiducial positions to change.

We add a notebook that allows the users to re-align the co-registration process with the new fiducial locations.

**How did you implement your changes**

The notebook, `update_coregistration_parameters.ipynb`, allows the user to specify the top 3 fiducials on the slide in both stage coordinates and optical pixel coordinates. These can be retrieved from the CAC.

Because the x- and y-coordinate axes are on different scales, we run separate regressions from stage coordinate to optical pixel coordinate values to generate the multiplier and offset values for both.

The multiplier is simply the slope of the regression. The offset is the x-intercept * -1: this is mostly a stylistic choice and `y = m(x + (x-intercept * -1))` is the same as `y = mx + b`. I feel it's a bit easier to understand in this context that we need to offset off of the stage coordinate then add a multiplication factor to retrieve the corresponding optical pixel coordinate. The concept of a y-intercept (b) is a little less intuitive in this context since no one will ever have a FOV with a stage coordinate of 0.

**Remaining issues**

Some possible aesthetic changes:

- Having a user prompt for the stage and pixel coordinate values of the fiducials
- Moving some processes to functions in `tiling_utils.py`