### PR TITLE
Don't check contrast for skimage save function.

### DIFF
--- a/toffy/file_hash_test.py
+++ b/toffy/file_hash_test.py
@@ -15,7 +15,7 @@ def test_get_hash():
         for img in range(2):
             array = np.random.rand(36).reshape((6, 6))
             temp_file_path = os.path.join(temp_dir, 'test_file_{}.tiff'.format(img))
-            io.imsave(temp_file_path, array)
+            io.imsave(temp_file_path, array, check_contrast=False)
 
         shutil.copy(os.path.join(temp_dir, 'test_file_0.tiff'),
                     os.path.join(temp_dir, 'test_file_0_copy.tiff'))
@@ -37,7 +37,7 @@ def test_compare_directories():
         for img in range(5):
             array = np.random.rand(36).reshape((6, 6))
             temp_file_path = os.path.join(dir_1, 'test_file_{}.tiff'.format(img))
-            io.imsave(temp_file_path, array)
+            io.imsave(temp_file_path, array, check_contrast = False)
 
         # copy same data into second directory
         dir_2 = os.path.join(top_level_dir, 'dir_2')


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes angelolab/ark-analysis#513. Removes the low contrast warnings for images.

**How did you implement your changes**

Manually added `check_contrast=False` to all instances of `skimage.io.imsave`.

**Remaining issues**

None ATM.
