### PR TITLE
Improves watcher tests

### DIFF
--- a/toffy/fov_watcher.py
+++ b/toffy/fov_watcher.py
@@ -166,7 +166,7 @@ class FOV_EventHandler(FileSystemEventHandler):
         try:
             fov_ready, point_name = self.run_structure.check_run_condition(event.src_path)
         except TimeoutError as timeout_error:
-            print('Encountered TimeoutError error: ' + timeout_error)
+            print(f'Encountered TimeoutError error: {timeout_error}')
             logf = open(self.log_path, 'a')
             logf.write(
                 f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- '

--- a/toffy/fov_watcher_test.py
+++ b/toffy/fov_watcher_test.py
@@ -28,8 +28,6 @@ def _slow_copy_sample_tissue_data(dest: str, delta: int = 10, one_blank: bool = 
             Time (in seconds) between each file copy
     """
 
-    print('copytime')
-
     for tissue_file in sorted(os.listdir(TISSUE_DATA_PATH)):
         time.sleep(delta)
         if one_blank and '.bin' in tissue_file:
@@ -38,7 +36,6 @@ def _slow_copy_sample_tissue_data(dest: str, delta: int = 10, one_blank: bool = 
             one_blank = False
         else:
             shutil.copy(os.path.join(TISSUE_DATA_PATH, tissue_file), dest)
-    print('copies done!')
 
 
 TISSUE_RUN_JSON_SPOOF = {

--- a/toffy/test_utils.py
+++ b/toffy/test_utils.py
@@ -4,7 +4,7 @@ import functools
 from pathlib import Path
 
 import pytest
-from pytest_cases import case
+from pytest_cases import case, parametrize
 
 import pandas as pd
 
@@ -150,9 +150,17 @@ class ExtractionQCCallCases:
 
 
 class WatcherCases:
-    def case_default(self):
+    @parametrize(intensity=(False, True))
+    def case_default(self, intensity):
         panel = pd.read_csv(os.path.join(Path(__file__).parent, 'data', 'sample_panel_tissue.csv'))
+        validators = [
+            functools.partial(
+                check_extraction_dir_structure,
+                channels=list(panel['Target']),
+                intensities=intensity),
+            check_qc_dir_structure,
+        ]
         return [
-            functools.partial(build_extract_callback, panel=panel),
+            functools.partial(build_extract_callback, panel=panel, intensities=intensity),
             functools.partial(build_qc_callback, panel=panel),
-        ], []
+        ], [], validators

--- a/toffy/watcher_callbacks.py
+++ b/toffy/watcher_callbacks.py
@@ -33,6 +33,9 @@ def build_extract_callback(out_dir: str, panel: pd.DataFrame,
         raise TypeError('Global unit mass integration is no longer support. Please provide panel '
                         'as a pandas DataFrame...')
 
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
     def extract_callback(run_folder: str, point_name: str):
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
@@ -66,6 +69,9 @@ def build_qc_callback(out_dir: str, panel: pd.DataFrame, **kwargs) -> Callable[[
                         'as a pandas DataFrame...')
 
     kwargs['save_csv'] = False
+
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
 
     def qc_callback(run_folder: str, point_name: str):
         metric_data = compute_qc_metrics(run_folder, point_name, None, panel, **kwargs)


### PR DESCRIPTION
## **Purpose**

Adds more coverage to watcher testing.  Also adds generalizable directory output validation.

## **Implementation**

Parametrizes standard cases over intensity extraction.  Uses functools.partial to help create per-case validators within the watcher case

## **Remaining issues**

per_run testing, but that's left to whoever first implements a per_run callback
