### PR TITLE
Rename fov folders

### DIFF
--- a/templates/2_create_tma_mibi_run.ipynb
+++ b/templates/2_create_tma_mibi_run.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "ffb9155f-3884-41fa-95b3-216ade6dfdc0",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "72a680b2",
    "metadata": {},
    "outputs": [],
@@ -58,6 +58,7 @@
     "from skimage.io import imread\n",
     "\n",
     "from toffy import tiling_utils\n",
+    "from toffy import rename_fovs\n",
     "\n",
     "# suppress mpl deprecation\n",
     "import warnings\n",
@@ -91,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "d30c1dbd",
    "metadata": {},
    "outputs": [],
@@ -162,7 +163,8 @@
     "with open(manual_run_path, 'r', encoding='utf-8') as mfop:\n",
     "    manual_fov_regions = json.load(mfop)\n",
     "    \n",
-    "# ensure duplicate FOV names get identified\n",
+    "# ensure missing and duplicate FOV names get identified\n",
+    "manual_fov_regions = rename_fovs.rename_missing_fovs(manual_fov_regions)\n",
     "manual_fov_regions = tiling_utils.rename_duplicate_fovs(manual_fov_regions)"
    ]
   },
@@ -301,9 +303,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "toffy_env",
    "language": "python",
-   "name": "python3"
+   "name": "toffy_env"
   },
   "language_info": {
    "codemirror_mode": {

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -75,10 +75,9 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             new_name = os.path.join(change_dir, fov_scan[folder])
             os.rename(fov_subdir, new_name)
 
-
-'''
+"""
 #r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
 r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
 f = os.path.join("data", "fov_folders")
 n = os.path.join("data", "new_names")
-rename_fov_dirs(r, f, n)'''
+rename_fov_dirs(r, f, n)"""

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -52,11 +52,10 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     #testing
     #test = list(fov_scan)[0:5]
     #fov_scan = {t: fov_scan[t] for t in test}
-    #print(fov_scan)
 
     #check that fovs & scan counts match the number of existing FOV directories
-    if name_count != dir_count:
-        raise ValueError(f"FOV folders do not match expected amount listed in the run file")
+    #if name_count != dir_count:
+    #    raise ValueError(f"FOV folders do not match expected amount listed in the run file")
 
     # create new directory and copy contents of fov_dir
     if new_dir is not None:
@@ -71,8 +70,9 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     for folder in fov_scan:
         fov_subdir = os.path.join(change_dir, folder)
         new_name = os.path.join(change_dir, fov_scan[folder])
-        os.rename(fov_subdir, new_name)
-        renamed_dirs += 1
+        if os.path.isdir(fov_subdir):
+            os.rename(fov_subdir, new_name)
+            renamed_dirs += 1
 
 
 

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -47,6 +47,11 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     io_utils.validate_paths(run_path)
     io_utils.validate_paths(fov_dir)
 
+    # check that new_dir doesn't already exist
+    if new_dir is not None:
+        if os.path.exists(new_dir):
+            raise ValueError(f"The new directory supplied already exists: {new_dir}")
+
     with open(run_path) as file:
         run_metadata = json.load(file)
 
@@ -87,7 +92,6 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
     # validate new_dir and copy contents of fov_dir
     if new_dir is not None:
-        io_utils.validate_paths(fov_dir)
         copy_tree(fov_dir, new_dir)
         change_dir = new_dir
     else:

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -15,9 +15,9 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         new_dir (str): path to the new directory to output files to, defaults to None
 
     Raises:
-        KeyError : issue reading keys from the JSON file
-        ValueError : there are existing FOV directories that are not described the run file
-        UserWarning : not all fov names in the run file have an existing directory
+        KeyError: issue reading keys from the JSON file
+        ValueError: there are existing FOV directories that are not described the run file
+        UserWarning: not all fov names in the run file have an existing directory
 
         """
 
@@ -56,12 +56,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     if not set(fov_scan.keys()).issubset(set(old_dirs)):
         warnings.warn(f"Not all FOVs listed in {run_path} have an existing directory")
 
-    #testing
-    #test = list(fov_scan)[0:5]
-    #fov_scan = {t: fov_scan[t] for t in test}
-    #print(fov_scan)
-
-    # create new directory and copy contents of fov_dir
+    #validate new_dir and copy contents of fov_dir
     if new_dir is not None:
         io_utils.validate_paths(fov_dir)
         copy_tree(fov_dir, new_dir)
@@ -70,18 +65,16 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         change_dir = fov_dir
 
     #change the FOV directory names
-    renamed_dirs = 0
     for folder in fov_scan:
         fov_subdir = os.path.join(change_dir, folder)
         if os.path.isdir(fov_subdir):
             new_name = os.path.join(change_dir, fov_scan[folder])
             os.rename(fov_subdir, new_name)
-            renamed_dirs += 1
 
 
-
-#r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
-r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
+'''
+r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
+#r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
 f = os.path.join("data", "fov_folders")
 n = os.path.join("data", "new_names")
-rename_fov_dirs(r, f, n)
+rename_fov_dirs(r, f, n)'''

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -71,8 +71,11 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             default_name = f'fov-{run_order}-scan-{scans}'
             fov_scan[default_name] = custom_name
 
-    # retrieve the current default directory names
+    # retrieve current default directory names, if empty there are no default names to change
     old_dirs = io_utils.list_folders(fov_dir, "fov")
+    if not old_dirs:
+        warnings.warn(f"No directories in {fov_dir} require renaming")
+        return
 
     # check if custom fov names & scan counts match the number of existing default directories
     try:
@@ -102,3 +105,4 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 # f = os.path.join("data", "fov_folders")
 # n = os.path.join("data", "new_names")
 # rename_fov_dirs(r, f, n)
+# rename_fov_dirs(r, f)

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -55,8 +55,8 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     #print(fov_scan)
 
     #check that fovs & scan counts match the number of existing FOV directories
-    if name_count != dir_count:
-        raise ValueError(f"FOV folders do not match expected amount listed in the run file")
+    #if name_count != dir_count:
+    #    raise ValueError(f"FOV folders do not match expected amount listed in the run file")
 
     # create new directory and copy contents of fov_dir
     if new_dir is not None:
@@ -70,9 +70,10 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     renamed_dirs = 0
     for folder in fov_scan:
         fov_subdir = os.path.join(change_dir, folder)
-        new_name = os.path.join(change_dir, fov_scan[folder])
-        os.rename(fov_subdir, new_name)
-        renamed_dirs += 1
+        if os.path.isdir(fov_subdir):
+            new_name = os.path.join(change_dir, fov_scan[folder])
+            os.rename(fov_subdir, new_name)
+            renamed_dirs += 1
 
 
 

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -3,7 +3,7 @@ import json
 from ark.utils import io_utils
 
 
-def rename_fov_dirs(run_dir, fov_dir, new_dir=FALSE):
+def rename_fov_dirs(run_dir, fov_dir, new_dir=False):
     """Renames FOV directories to have specific names sources from the run JSON file
 
     Args:
@@ -15,7 +15,7 @@ def rename_fov_dirs(run_dir, fov_dir, new_dir=FALSE):
         """
 
     io_utils.validate_paths(run_dir)
-    io_utils.validate_paths(run_dir)
+    io_utils.validate_paths(fov_dir)
 
     #retieve FOV names and number of scans for each
     with open(run_dir) as f:

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -10,14 +10,14 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     """Renames FOV directories with default_name to have custom_name sourced from the run JSON file
 
     Args:
-        run_path (str): path to the JSON run file which contains custom_name values
-        fov_dir (str): directory where the FOV default_name subdirectories are stored
+        run_path (str): path to the JSON run file which contains custom name values
+        fov_dir (str): directory where the FOV default named subdirectories are stored
         new_dir (str): path to new directory to output renamed folders and files to, defaults to None
 
     Raises:
         KeyError: issue reading keys from the JSON file
-        ValueError: there are existing default_name directories that are not described in the run file
-        UserWarning: not all custom_names from the run file have an existing directory
+        ValueError: there are existing default named directories that are not described in the run file
+        UserWarning: not all custom names from the run file have an existing directory
 
         """
 
@@ -26,7 +26,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
     #insert some kind of fov name validation
 
-    #retieve FOV names and number of scans for each
+    #retieve custom names and number of scans for each fov, construct matching default names
     with open(run_path) as f:
         run_metadata = json.load(f)
 
@@ -46,10 +46,10 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             default_name = f'fov-{run_order}-scan-{scans}'
             fov_scan[default_name] = custom_name
 
-    #retrieve the current FOV directory names
+    #retrieve the current default directory names
     old_dirs = io_utils.list_folders(fov_dir, "fov")
 
-    #check that fovs & scan counts match the number of existing FOV directories
+    #check if custom fov names & scan counts match the number of existing default directories
     if not set(old_dirs).issubset(set(fov_scan.keys())):
         raise ValueError(f"FOV folders exceed the expected amount listed in {run_path}")
     if not set(fov_scan.keys()).issubset(set(old_dirs)):

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -52,10 +52,11 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     #testing
     #test = list(fov_scan)[0:5]
     #fov_scan = {t: fov_scan[t] for t in test}
+    #print(fov_scan)
 
     #check that fovs & scan counts match the number of existing FOV directories
-    #if name_count != dir_count:
-    #    raise ValueError(f"FOV folders do not match expected amount listed in the run file")
+    if name_count != dir_count:
+        raise ValueError(f"FOV folders do not match expected amount listed in the run file")
 
     # create new directory and copy contents of fov_dir
     if new_dir is not None:
@@ -70,9 +71,8 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     for folder in fov_scan:
         fov_subdir = os.path.join(change_dir, folder)
         new_name = os.path.join(change_dir, fov_scan[folder])
-        if os.path.isdir(fov_subdir):
-            os.rename(fov_subdir, new_name)
-            renamed_dirs += 1
+        os.rename(fov_subdir, new_name)
+        renamed_dirs += 1
 
 
 

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -24,7 +24,7 @@ def check_unnamed_fovs(fov_data):
     for fov in fov_data['fovs']:
         if 'name' not in fov.keys():
             missing_count += 1
-            fov_data[fov['name']] = f'placeholder_{missing_count}'
+            fov['name'] = f'placeholder_{missing_count}'
 
     return fov_data
 
@@ -102,6 +102,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
 # r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
 # r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
+# r = os.path.join("data", "json_test", "DCIS_Dress_corners.json")
 # f = os.path.join("data", "fov_folders")
 # n = os.path.join("data", "new_names")
 # rename_fov_dirs(r, f, n)

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -7,22 +7,24 @@ from ark.utils import io_utils
 
 
 def rename_fov_dirs(run_path, fov_dir, new_dir=None):
-    """Renames FOV directories to have specific names sources from the run JSON file
+    """Renames FOV directories with default_name to have custom_name sourced from the run JSON file
 
     Args:
-        run_path (str): path to the JSON run file
-        fov_dir (str): directory where the FOV subdirectories are stored
-        new_dir (str): path to the new directory to output files to, defaults to None
+        run_path (str): path to the JSON run file which contains custom_name values
+        fov_dir (str): directory where the FOV default_name subdirectories are stored
+        new_dir (str): path to new directory to output renamed folders and files to, defaults to None
 
     Raises:
         KeyError: issue reading keys from the JSON file
-        ValueError: there are existing FOV directories that are not described the run file
-        UserWarning: not all fov names in the run file have an existing directory
+        ValueError: there are existing default_name directories that are not described in the run file
+        UserWarning: not all custom_names from the run file have an existing directory
 
         """
 
     io_utils.validate_paths(run_path)
     io_utils.validate_paths(fov_dir)
+
+    #insert some kind of fov name validation
 
     #retieve FOV names and number of scans for each
     with open(run_path) as f:
@@ -30,7 +32,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
     fov_scan = dict()
     for fov in run_metadata.get('fovs', ()):
-        name = fov.get('name')
+        custom_name = fov.get('name')
         run_order = fov.get('runOrder', -1)
         scans = fov.get('scanCount', -1)
         if run_order * scans < 0:
@@ -38,14 +40,11 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
         if scans > 1:
             for scan in range(1, scans+1):
-                fov_name = f'fov-{run_order}-scan-{scan}'
-                fov_scan[fov_name] = f'{name}-{scan}'
+                default_name = f'fov-{run_order}-scan-{scan}'
+                fov_scan[default_name] = f'{custom_name}-{scan}'
         else:
-            fov_name = f'fov-{run_order}-scan-{scans}'
-            fov_scan[fov_name] = name
-
-    #insert some kind of fov name validation
-
+            default_name = f'fov-{run_order}-scan-{scans}'
+            fov_scan[default_name] = custom_name
 
     #retrieve the current FOV directory names
     old_dirs = io_utils.list_folders(fov_dir, "fov")
@@ -64,7 +63,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     else:
         change_dir = fov_dir
 
-    #change the FOV directory names
+    #change the default directory names to custom names
     for folder in fov_scan:
         fov_subdir = os.path.join(change_dir, folder)
         if os.path.isdir(fov_subdir):

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -28,7 +28,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         run_order = fov.get('runOrder', -1)
         scans = fov.get('scanCount', -1)
         if run_order * scans < 0:
-            raise KeyError(f"Could not locate keys in {run_path}.json")
+            raise KeyError(f"Could not locate keys in {run_path}")
 
         if scans > 1:
             for scan in range(1, scans+1):
@@ -44,10 +44,8 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     #insert some kind of fov name validation
 
 
-    #retrieve number of current FOV directories and their names
+    #retrieve the current FOV directory names
     old_dirs = io_utils.list_folders(fov_dir, "fov")
-    dir_count = len(old_dirs)
-    #old_dirs.sort()
 
     #testing
     #test = list(fov_scan)[0:5]
@@ -55,8 +53,10 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     #print(fov_scan)
 
     #check that fovs & scan counts match the number of existing FOV directories
-    #if name_count != dir_count:
-    #    raise ValueError(f"FOV folders do not match expected amount listed in the run file")
+    if not set(old_dirs).issubset(set(fov_scan.keys())):
+        raise ValueError(f"FOV folders exceed the expected amount listed in {run_path}")
+    if not set(fov_scan.keys()).issubset(set(old_dirs)):
+        raise Warning(f"Not all FOVs listed in {run_path} have an existing directory")
 
     # create new directory and copy contents of fov_dir
     if new_dir is not None:
@@ -64,7 +64,6 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         change_dir = new_dir
     else:
         change_dir = fov_dir
-
 
     #change the FOV directory names
     renamed_dirs = 0
@@ -76,10 +75,9 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             renamed_dirs += 1
 
 
-
-
+'''
 #r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
 r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
 f = os.path.join("data", "fov_folders")
 n = os.path.join("data", "new_names")
-rename_fov_dirs(r, f, n)
+rename_fov_dirs(r, f, n)'''

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -14,3 +14,11 @@ def rename_fov_dirs(run_dir, fov_dir, new_dir=FALSE):
     Returns:
         """
 
+    io_utils.validate_paths(run_dir)
+    io_utils.validate_paths(run_dir)
+
+    #retieve FOV names and number of scans for each
+    with open(run_dir) as f:
+        data = json.load(f)
+        run_data = data['fovs']
+        fov_scan = {x['name']: x['scanCount'] for x in run_data}

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -60,8 +60,6 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
     # create new directory and copy contents of fov_dir
     if new_dir is not None:
-        parent = os.path.join(fov_dir, os.pardir)
-        new_dir = os.path.join(parent, new_dir)
         copy_tree(fov_dir, new_dir)
         change_dir = new_dir
     else:

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -34,11 +34,12 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=False):
     #retrieve number of current FOV directories and their names
     old_dirs = io_utils.list_folders(fov_dir, "fov")
     dir_count = len(old_dirs)
+    old_dirs.sort()
 
     #testing
     #test = list(fov_scan)[0:5]
     #fov_scan = {t: fov_scan[t] for t in test}
-    #print(fov_test)
+    #print(fov_scan)
 
     #check that fovs & scan counts match the number of existing FOV directories
     if name_count != dir_count:

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -11,22 +11,24 @@ from toffy.tiling_utils import rename_duplicate_fovs
 def rename_missing_fovs(fov_data):
     """Identify FOVs that are missing the 'name' key and create one with value placeholder_{n}
     Args:
-        fov_data (dict): the FOV run JSON
+        fov_data (dict): the FOV run JSON data
 
     Returns:
-        dict: the same run JSON with placeholder names for FOVs that lack one
+        dict: a copy of the run JSON data with placeholder names for FOVs that lack one
        """
+
+    copy_fov_data = fov_data
 
     # count of FOVs that are missing the 'name' key
     missing_count = 0
 
     # iterate over each FOV and add a placeholder name if necessary
-    for fov in fov_data['fovs']:
+    for fov in copy_fov_data['fovs']:
         if 'name' not in fov.keys():
             missing_count += 1
             fov['name'] = f'placeholder_{missing_count}'
 
-    return fov_data
+    return copy_fov_data
 
 
 def rename_fov_dirs(run_path, fov_dir, new_dir=None):

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -102,11 +102,3 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         if os.path.isdir(fov_subdir):
             new_name = os.path.join(change_dir, fov_scan[folder])
             os.rename(fov_subdir, new_name)
-
-# r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
-# r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
-# r = os.path.join("data", "json_test", "DCIS_Dress_corners.json")
-# f = os.path.join("data", "fov_folders")
-# n = os.path.join("data", "new_names")
-# rename_fov_dirs(r, f, n)
-# rename_fov_dirs(r, f)

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -76,7 +76,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             default_name = f'fov-{run_order}-scan-{scans}'
             fov_scan[default_name] = custom_name
 
-    # retrieve current default directory names, if empty there are no default names to change
+    # retrieve current default directory names, check if already renamed
     old_dirs = io_utils.list_folders(fov_dir)
     if set(old_dirs) == set(fov_scan.values()):
         raise ValueError(f"All FOV folders in {fov_dir} have already been renamed")

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -3,7 +3,8 @@ import os
 import warnings
 from distutils.dir_util import copy_tree
 
-from ark.utils import io_utils, misc_utils
+from ark.utils import io_utils
+from ark.utils.misc_utils import verify_in_list
 from toffy.tiling_utils import rename_duplicate_fovs
 
 
@@ -34,11 +35,11 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     Args:
         run_path (str): path to the JSON run file which contains custom name values
         fov_dir (str): directory where the FOV default named subdirectories are stored
-        new_dir (str): path to new directory to output renamed folders and files to, defaults to None
+        new_dir (str): path to new directory to output renamed folders to, defaults to None
 
     Raises:
         KeyError: issue reading keys from the JSON file
-        ValueError: there are existing default named directories that are not described in the run file
+        ValueError: there exist default named directories that are not described in the run file
         UserWarning: not all custom names from the run file have an existing directory
 
         """
@@ -75,11 +76,11 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
 
     # check if custom fov names & scan counts match the number of existing default directories
     try:
-        misc_utils.verify_in_list(default=list(fov_scan.keys()), existing_folders=old_dirs)
+        verify_in_list(default=list(fov_scan.keys()), existing_folders=old_dirs)
     except ValueError:
         warnings.warn(f"Not all FOVs specified in {run_path} have an existing directory")
 
-    misc_utils.verify_in_list(existing_FOV_folders_not_found_in_run_file=old_dirs, default=list(fov_scan.keys()))
+    verify_in_list(existing_folders_not_found_in_run_file=old_dirs, default=list(fov_scan.keys()))
 
     # validate new_dir and copy contents of fov_dir
     if new_dir is not None:
@@ -96,8 +97,8 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             new_name = os.path.join(change_dir, fov_scan[folder])
             os.rename(fov_subdir, new_name)
 
-#r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
-#r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
-#f = os.path.join("data", "fov_folders")
-#n = os.path.join("data", "new_names")
-#rename_fov_dirs(r, f, n)
+# r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
+# r = os.path.join("data", "json_test", "2022-01-14_postsweep_2.json")
+# f = os.path.join("data", "fov_folders")
+# n = os.path.join("data", "new_names")
+# rename_fov_dirs(r, f, n)

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -3,22 +3,22 @@ import json
 from ark.utils import io_utils
 
 
-def rename_fov_dirs(run_dir, fov_dir, new_dir=False):
+def rename_fov_dirs(run_path, fov_dir, new_dir=False):
     """Renames FOV directories to have specific names sources from the run JSON file
 
     Args:
-        run_dir (str): directory with the json run file
+        run_path (str): path to the JSON run file
         fov_dir (str): directory where the FOV subdirectories are stored
         new_dir (bool): whether or not to output renamed folders to a new directory
 
     Returns:
         """
 
-    io_utils.validate_paths(run_dir)
+    io_utils.validate_paths(run_path)
     io_utils.validate_paths(fov_dir)
 
     #retieve FOV names and number of scans for each
-    with open(run_dir) as f:
+    with open(run_path) as f:
         data = json.load(f)
         run_data = data['fovs']
         fov_scan = {x['name']: x['scanCount'] for x in run_data}
@@ -36,5 +36,8 @@ def rename_fov_dirs(run_dir, fov_dir, new_dir=False):
     old_dirs = io_utils.list_folders(fov_dir, "fov")
     dir_count = len(old_dirs)
 
+    #check that fovs & scan counts match the number of existing FOV directories
+    if name_count != dir_count:
+        raise ValueError(f"FOV folders do not match expected amount listed in the run file")
 
 #rename_fov_dirs("data/json_test/2022-04-07_TONIC_TMA21_run1.json", "data/fov_folders")

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -8,7 +8,7 @@ from ark.utils.misc_utils import verify_in_list
 from toffy.tiling_utils import rename_duplicate_fovs
 
 
-def check_unnamed_fovs(fov_data):
+def rename_missing_fovs(fov_data):
     """Identify FOVs that are missing the 'name' key and create one with value placeholder_{n}
     Args:
         fov_data (dict): the FOV run JSON
@@ -56,7 +56,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         run_metadata = json.load(file)
 
     # check for missing or duplicate fov names
-    run_metadata = check_unnamed_fovs(run_metadata)
+    run_metadata = rename_missing_fovs(run_metadata)
     run_metadata = rename_duplicate_fovs(run_metadata)
 
     # retrieve custom names and number of scans for each fov, construct matching default names

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -1,6 +1,7 @@
 import json
 import os
 import warnings
+import copy
 from distutils.dir_util import copy_tree
 
 from ark.utils import io_utils
@@ -17,7 +18,7 @@ def rename_missing_fovs(fov_data):
         dict: a copy of the run JSON data with placeholder names for FOVs that lack one
        """
 
-    copy_fov_data = fov_data
+    copy_fov_data = copy.deepcopy(fov_data)
 
     # count of FOVs that are missing the 'name' key
     missing_count = 0

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -77,10 +77,9 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
             fov_scan[default_name] = custom_name
 
     # retrieve current default directory names, if empty there are no default names to change
-    old_dirs = io_utils.list_folders(fov_dir, "fov")
-    if not old_dirs:
-        warnings.warn(f"No directories in {fov_dir} require renaming")
-        return
+    old_dirs = io_utils.list_folders(fov_dir)
+    if set(old_dirs) == set(fov_scan.values()):
+        raise ValueError(f"All FOV folders in {fov_dir} have already been renamed")
 
     # check if custom fov names & scan counts match the number of existing default directories
     try:

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -79,10 +79,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     except ValueError:
         warnings.warn(f"Not all FOVs specified in {run_path} have an existing directory")
 
-    try:
-        misc_utils.verify_in_list(existing_folders=old_dirs, default=list(fov_scan.keys()))
-    except ValueError:
-        raise ValueError(f"FOV folders exceed the expected amount specified in {run_path}")
+    misc_utils.verify_in_list(existing_FOV_folders_not_found_in_run_file=old_dirs, default=list(fov_scan.keys()))
 
     # validate new_dir and copy contents of fov_dir
     if new_dir is not None:

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -1,16 +1,17 @@
 import json
 import os
+from distutils.dir_util import copy_tree
 
 from ark.utils import io_utils
 
 
-def rename_fov_dirs(run_path, fov_dir, new_dir=False):
+def rename_fov_dirs(run_path, fov_dir, new_dir=None):
     """Renames FOV directories to have specific names sources from the run JSON file
 
     Args:
         run_path (str): path to the JSON run file
         fov_dir (str): directory where the FOV subdirectories are stored
-        new_dir (bool): whether or not to output renamed folders to a new directory
+        new_dir (str): name of new directory to output files to, defaults to None
 
         """
 
@@ -45,13 +46,23 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=False):
     if name_count != dir_count:
         raise ValueError(f"FOV folders do not match expected amount listed in the run file")
 
+    # create new directory and copy contents of fov_dir
+    if new_dir is not None:
+        parent = os.path.join(fov_dir, os.pardir)
+        new_dir = os.path.join(parent, new_dir)
+        copy_tree(fov_dir, new_dir)
+
     #change the FOV directory names
     renamed_dirs = 0
     for fov in fov_scan:
         scan_num = fov_scan[fov]
         for scan in range(1, scan_num+1):
-            fov_subdir = os.path.join(fov_dir, old_dirs[renamed_dirs])
-            new_name = os.path.join(fov_dir, fov+"-scan-"+str(scan))
+            if new_dir is not None:
+                change_dir = new_dir
+            else:
+                change_dir = fov_dir
+            fov_subdir = os.path.join(change_dir, old_dirs[renamed_dirs])
+            new_name = os.path.join(change_dir, fov + "-scan-" + str(scan))
             os.rename(fov_subdir, new_name)
             renamed_dirs += 1
 
@@ -59,4 +70,5 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=False):
 '''
 r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
 f = os.path.join("data", "fov_folders")
-rename_fov_dirs(r, f)'''
+n = 'new_directory_name'
+rename_fov_dirs(r, f, n)'''

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -22,3 +22,19 @@ def rename_fov_dirs(run_dir, fov_dir, new_dir=False):
         data = json.load(f)
         run_data = data['fovs']
         fov_scan = {x['name']: x['scanCount'] for x in run_data}
+
+
+    #determine how many folders will be changed
+    name_count = 0
+    for fov in fov_scan:
+        name_count += (1*fov_scan[fov])
+
+    #insert some kind of fov name validation
+
+
+    #retrieve number of current FOV directory and their names
+    old_dirs = io_utils.list_folders(fov_dir, "fov")
+    dir_count = len(old_dirs)
+
+
+#rename_fov_dirs("data/json_test/2022-04-07_TONIC_TMA21_run1.json", "data/fov_folders")

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from ark.utils import io_utils
 
@@ -11,7 +12,6 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=False):
         fov_dir (str): directory where the FOV subdirectories are stored
         new_dir (bool): whether or not to output renamed folders to a new directory
 
-    Returns:
         """
 
     io_utils.validate_paths(run_path)
@@ -23,7 +23,6 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=False):
         run_data = data['fovs']
         fov_scan = {x['name']: x['scanCount'] for x in run_data}
 
-
     #determine how many folders will be changed
     name_count = 0
     for fov in fov_scan:
@@ -32,12 +31,31 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=False):
     #insert some kind of fov name validation
 
 
-    #retrieve number of current FOV directory and their names
+    #retrieve number of current FOV directories and their names
     old_dirs = io_utils.list_folders(fov_dir, "fov")
     dir_count = len(old_dirs)
+
+    #testing
+    #test = list(fov_scan)[0:5]
+    #fov_scan = {t: fov_scan[t] for t in test}
+    #print(fov_test)
 
     #check that fovs & scan counts match the number of existing FOV directories
     if name_count != dir_count:
         raise ValueError(f"FOV folders do not match expected amount listed in the run file")
 
-#rename_fov_dirs("data/json_test/2022-04-07_TONIC_TMA21_run1.json", "data/fov_folders")
+    #change the FOV directory names
+    renamed_dirs = 0
+    for fov in fov_scan:
+        scan_num = fov_scan[fov]
+        for scan in range(1, scan_num+1):
+            fov_subdir = os.path.join(fov_dir, old_dirs[renamed_dirs])
+            new_name = os.path.join(fov_dir, fov+"-scan-"+str(scan))
+            os.rename(fov_subdir, new_name)
+            renamed_dirs += 1
+
+
+'''
+r = os.path.join("data", "json_test", "2022-04-07_TONIC_TMA21_run1.json")
+f = os.path.join("data", "fov_folders")
+rename_fov_dirs(r, f)'''

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -68,6 +68,7 @@ def rename_fov_dirs(run_path, fov_dir, new_dir=None):
         if run_order * scans < 0:
             raise KeyError(f"Could not locate keys in {run_path}")
 
+        # fovs with multiple scans have scan number specified
         if scans > 1:
             for scan in range(1, scans + 1):
                 default_name = f'fov-{run_order}-scan-{scan}'

--- a/toffy/rename_fovs.py
+++ b/toffy/rename_fovs.py
@@ -1,0 +1,16 @@
+import json
+
+from ark.utils import io_utils
+
+
+def rename_fov_dirs(run_dir, fov_dir, new_dir=FALSE):
+    """Renames FOV directories to have specific names sources from the run JSON file
+
+    Args:
+        run_dir (str): directory with the json run file
+        fov_dir (str): directory where the FOV subdirectories are stored
+        new_dir (bool): whether or not to output renamed folders to a new directory
+
+    Returns:
+        """
+

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -12,6 +12,7 @@ def create_sample_run(data, create_json=False):
     fov_list = []
     sample_run = {"fovs": fov_list}
 
+    # set up dictionary
     for name, run_order, scan_count in zip(data.loc[:, "names"], data.loc[:, "run"], data.loc[:, "scans"]):
         ex_fov = {
             "scanCount": scan_count,
@@ -20,10 +21,12 @@ def create_sample_run(data, create_json=False):
         }
         fov_list.append(ex_fov)
 
+    # delete name key if one is not provided
     for fov in sample_run.get('fovs', ()):
         if fov.get('name') is None:
             del fov['name']
 
+    # create json file for the data
     if create_json:
         temp = tempfile.NamedTemporaryFile(mode="w")
         json.dump(sample_run, temp)
@@ -34,16 +37,17 @@ def create_sample_run(data, create_json=False):
 
 
 def test_check_unnamed_fovs():
-    ex_name = ['MoQC', None, 'tonsil_bottom', 'moly_qc_tissue', None]
-    ex_run_order = list(range(1, 6))
-    ex_scan_count = list(range(1, 6))
+    # data with missing names
     ex_data = pd.DataFrame(
-        {'names': ex_name,
-         'run': ex_run_order,
-         'scans': ex_scan_count
+        {'names': ['MoQC', None, 'tonsil_bottom', 'moly_qc_tissue', None],
+         'run': list(range(1, 6)),
+         'scans': list(range(1, 6))
          })
+
+    # create a dict with the sample data
     ex_run = create_sample_run(ex_data)
 
+    # test that missing names are given a placeholder
     rename_fovs.check_unnamed_fovs(ex_run)
     for fov in ex_run.get('fovs', ()):
         assert fov.get('name') is not None
@@ -67,4 +71,4 @@ def test_rename_fov_dirs():
         rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
 
 
-#test_rename_fov_dirs()
+# test_rename_fov_dirs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -9,7 +9,7 @@ from ark.utils import io_utils
 from toffy import rename_fovs as rf
 
 
-def create_sample_run(data, create_json=False):
+def create_sample_run(data, create_json=False, bad=False):
     fov_list = []
     sample_run = {"fovs": fov_list}
 
@@ -28,6 +28,11 @@ def create_sample_run(data, create_json=False):
         if fov.get('name') is None:
             del fov['name']
 
+    # create bad dictionary
+    if bad:
+        sample_run['bad key'] = sample_run['fovs']
+        del sample_run['fovs']
+
     # create json file for the data
     if create_json:
         temp = tempfile.NamedTemporaryFile(mode="w", delete=False)
@@ -39,11 +44,13 @@ def create_sample_run(data, create_json=False):
 
 
 def create_sample_fov_dirs(fovs, base_dir):
+    # make fov subdirectories
     for fov in fovs:
         os.mkdir(os.path.join(base_dir, fov))
 
 
 def remove_fov_dirs(base_dir):
+    # delete fov subdirectories
     fovs = io_utils.list_folders(base_dir)
     for fov in fovs:
         os.rmdir(os.path.join(base_dir, fov))
@@ -83,8 +90,6 @@ def test_rename_fov_dirs():
         with pytest.raises(ValueError, match="already exists"):
             rf.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
 
-        # bad sample run data
-
         # regular sample run data
         ex_data = pd.DataFrame(
             {'names': ['MoQC', 'tonsil_bottom', 'moly_qc_tissue'],
@@ -94,6 +99,13 @@ def test_rename_fov_dirs():
 
         # create a json path with the sample data
         ex_run_path = create_sample_run(ex_data, True)
+
+        # bad sample run data
+        bad_run = create_sample_run(ex_data, True, bad=True)
+
+        # bad run file data should raise an error
+        with pytest.raises(KeyError):
+            rf.rename_fov_dirs(bad_run, fov_dir)
 
         # create already renamed fov folders
         renamed_fovs = ['MoQC', 'tonsil_bottom-1', 'tonsil_bottom-2', 'moly_qc_tissue']

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -2,16 +2,17 @@ import tempfile
 import json
 import os
 import pytest
+import pandas as pd
 
 # from ark.utils import test_utils
 from toffy import rename_fovs
 
 
-def create_sample_run(name_list, run_order_list, scan_count_list, create_json=False):
+def create_sample_run(data, create_json=False):
     fov_list = []
     sample_run = {"fovs": fov_list}
 
-    for name, run_order, scan_count in zip(name_list, run_order_list, scan_count_list):
+    for name, run_order, scan_count in zip(data.loc[:, "names"], data.loc[:, "run"], data.loc[:, "scans"]):
         ex_fov = {
             "scanCount": scan_count,
             "runOrder": run_order,
@@ -36,7 +37,12 @@ def test_check_unnamed_fovs():
     ex_name = ['MoQC', None, 'tonsil_bottom', 'moly_qc_tissue', None]
     ex_run_order = list(range(1, 6))
     ex_scan_count = list(range(1, 6))
-    ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
+    ex_data = pd.DataFrame(
+        {'names': ex_name,
+         'run': ex_run_order,
+         'scans': ex_scan_count
+         })
+    ex_run = create_sample_run(ex_data)
 
     rename_fovs.check_unnamed_fovs(ex_run)
     for fov in ex_run.get('fovs', ()):
@@ -56,10 +62,9 @@ def test_rename_fov_dirs():
         os.mkdir(os.path.join(base_dir, 'new_directory'))
         not_new_dir = os.path.join(base_dir, 'new_directory')
 
-        # test existing directory for new_dir
-        with pytest.raises(ValueError):
-            rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
+    # test existing directory for new_dir
+    with pytest.raises(ValueError):
+        rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
 
 
-
-# test_rename_fov_dirs()
+#test_rename_fov_dirs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -1,2 +1,29 @@
-from ark.utils import test_utils
+# import tempfile
 
+# from ark.utils import test_utils
+from toffy import rename_fovs
+
+
+def test_check_unnamed_fovs():
+    ex_name = ['fov-1', 'fov-2', 'fov-3', 'fov-4']
+    ex_run_order = [1, 2, 3, 4, 5]
+    ex_scan_count = [1, 2, 3, 4, 5]
+    ex_fov_list = []
+    sample_fov_scan = {"fovs": ex_fov_list}
+
+    for run_order, scan_count in zip(ex_run_order, ex_scan_count):
+        if not run_order > len(ex_name):
+            ex_fov = {
+                "scanCount": scan_count,
+                "runOrder": run_order,
+                "name": ex_name[run_order-1]
+            }
+        else:
+            ex_fov = {
+                "scanCount": scan_count,
+                "runOrder": run_order,
+            }
+        ex_fov_list.append(ex_fov)
+
+    print(sample_fov_scan)
+    rename_fovs.check_unnamed_fovs(sample_fov_scan)

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -8,15 +8,6 @@ from toffy import rename_fovs
 
 
 def create_sample_run(name_list, run_order_list, scan_count_list, create_json=False):
-    """Creates example run metadata, create temporary JSON file if required
-       Args:
-           lists
-           create_json (bool): whether to create temporary JSON file and return the path, defaults to False
-
-       Returns:
-           dict: correctly formatted dictionary of sample run metadata
-           path: the path to a temporary JSON file for the sample run
-          """
     fov_list = []
     sample_run = {"fovs": fov_list}
 
@@ -68,6 +59,7 @@ def test_rename_fov_dirs():
         # test existing directory for new_dir
         with pytest.raises(ValueError):
             rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
+
 
 
 # test_rename_fov_dirs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -14,7 +14,8 @@ def create_sample_run(data, create_json=False):
     sample_run = {"fovs": fov_list}
 
     # set up dictionary
-    for name, run_order, scan_count in zip(data.loc[:, "names"], data.loc[:, "run"], data.loc[:, "scans"]):
+    for name, run_order, scan_count in \
+            zip(data.loc[:, "names"], data.loc[:, "run"], data.loc[:, "scans"]):
         ex_fov = {
             "scanCount": scan_count,
             "runOrder": run_order,
@@ -120,12 +121,13 @@ def test_rename_fov_dirs():
         create_sample_fov_dirs(less_fovs, fov_dir)
 
         # fov folders already renamed should raise an error
-        with pytest.warns(match="Not all FOVs"):
+        with pytest.warns(UserWarning, match="Not all FOVs"):
             rf.rename_fov_dirs(ex_run_path, fov_dir)
         remove_fov_dirs(fov_dir)
 
         # create extra fov folders
-        extra_fovs = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-2-scan-2', 'fov-3-scan-1', 'fov-3-scan-3']
+        extra_fovs = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-2-scan-2',
+                      'fov-3-scan-1', 'fov-3-scan-3']
         create_sample_fov_dirs(extra_fovs, fov_dir)
 
         # fov folders already renamed should raise an error

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -28,7 +28,7 @@ def create_sample_run(name_list, run_order_list, scan_count_list, create_json=Fa
         fov_list.append(ex_fov)
 
     for fov in sample_run.get('fovs', ()):
-        if fov.get('name') == 'missing':
+        if fov.get('name') is None:
             del fov['name']
 
     if create_json:
@@ -41,12 +41,14 @@ def create_sample_run(name_list, run_order_list, scan_count_list, create_json=Fa
 
 
 def test_check_unnamed_fovs():
-    ex_name = ['MoQC', 'missing', 'tonsil_bottom', 'moly_qc_tissue', 'missing']
+    ex_name = ['MoQC', None, 'tonsil_bottom', 'moly_qc_tissue', None]
     ex_run_order = list(range(1, 6))
     ex_scan_count = list(range(1, 6))
     ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
     rename_fovs.check_unnamed_fovs(ex_run)
+    for fov in ex_run.get('fovs', ()):
+        assert fov.get('name') is not None
 
 
 def test_rename_fov_dirs():

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -40,12 +40,9 @@ def create_sample_run(name_list, run_order_list, scan_count_list, create_json=Fa
 
 
 def test_check_unnamed_fovs():
-    ex_name = ['fov-1', 'fov-2', 'fov-3', 'fov-4', 'missing']
+    ex_name = ['MoQC', 'missing', 'tonsil_bottom', 'moly_qc_tissue', 'missing']
     ex_run_order = list(range(1, 6))
     ex_scan_count = list(range(1, 6))
     ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
     rename_fovs.check_unnamed_fovs(ex_run)
-
-
-test_check_unnamed_fovs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -1,0 +1,2 @@
+from ark.utils import test_utils
+

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -1,5 +1,6 @@
 import tempfile
 import json
+import os
 
 # from ark.utils import test_utils
 from toffy import rename_fovs
@@ -46,3 +47,23 @@ def test_check_unnamed_fovs():
     ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
     rename_fovs.check_unnamed_fovs(ex_run)
+
+
+def test_rename_fov_dirs():
+    with tempfile.TemporaryDirectory() as base_dir:
+        # create run file and fov folder directories
+        dirs = ['run_folder', 'fov_folder']
+        for directory in dirs:
+            os.mkdir(os.path.join(base_dir, directory))
+        run_dir = os.path.join(base_dir, 'run_folder')
+        fov_dir = os.path.join(base_dir, 'fov_folder')
+
+        # create existing new directory
+        os.mkdir(os.path.join(base_dir, 'new_directory'))
+        not_new_dir = os.path.join(base_dir, 'new_directory')
+
+        # test existing directory for new_dir
+        rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
+
+
+# test_rename_fov_dirs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -1,29 +1,51 @@
-# import tempfile
+import tempfile
+import json
 
 # from ark.utils import test_utils
 from toffy import rename_fovs
 
 
+def create_sample_run(name_list, run_order_list, scan_count_list, create_json=False):
+    """Creates example run metadata, create temporary JSON file if required
+       Args:
+           lists
+           create_json (bool): whether to create temporary JSON file and return the path, defaults to False
+
+       Returns:
+           dict: correctly formatted dictionary of sample run metadata
+           path: the path to a temporary JSON file for the sample run
+          """
+    fov_list = []
+    sample_run = {"fovs": fov_list}
+
+    for name, run_order, scan_count in zip(name_list, run_order_list, scan_count_list):
+        ex_fov = {
+            "scanCount": scan_count,
+            "runOrder": run_order,
+            "name": name
+        }
+        fov_list.append(ex_fov)
+
+    for fov in sample_run.get('fovs', ()):
+        if fov.get('name') == 'missing':
+            del fov['name']
+
+    if create_json:
+        temp = tempfile.NamedTemporaryFile(mode="w")
+        json.dump(sample_run, temp)
+        print(temp.name)
+        return temp.name
+
+    return sample_run
+
+
 def test_check_unnamed_fovs():
-    ex_name = ['fov-1', 'fov-2', 'fov-3', 'fov-4']
-    ex_run_order = [1, 2, 3, 4, 5]
-    ex_scan_count = [1, 2, 3, 4, 5]
-    ex_fov_list = []
-    sample_fov_scan = {"fovs": ex_fov_list}
+    ex_name = ['fov-1', 'fov-2', 'fov-3', 'fov-4', 'missing']
+    ex_run_order = list(range(1, 6))
+    ex_scan_count = list(range(1, 6))
+    ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
-    for run_order, scan_count in zip(ex_run_order, ex_scan_count):
-        if not run_order > len(ex_name):
-            ex_fov = {
-                "scanCount": scan_count,
-                "runOrder": run_order,
-                "name": ex_name[run_order-1]
-            }
-        else:
-            ex_fov = {
-                "scanCount": scan_count,
-                "runOrder": run_order,
-            }
-        ex_fov_list.append(ex_fov)
+    rename_fovs.check_unnamed_fovs(ex_run)
 
-    print(sample_fov_scan)
-    rename_fovs.check_unnamed_fovs(sample_fov_scan)
+
+test_check_unnamed_fovs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -1,6 +1,7 @@
 import tempfile
 import json
 import os
+import pytest
 
 # from ark.utils import test_utils
 from toffy import rename_fovs
@@ -65,7 +66,8 @@ def test_rename_fov_dirs():
         not_new_dir = os.path.join(base_dir, 'new_directory')
 
         # test existing directory for new_dir
-        rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
+        with pytest.raises(ValueError):
+            rename_fovs.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
 
 
 # test_rename_fov_dirs()

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -52,7 +52,7 @@ def remove_fov_dirs(base_dir):
         os.rmdir(os.path.join(base_dir, fov))
 
 
-def test_check_unnamed_fovs():
+def test_rename_missing_fovs():
     # data with missing names
     ex_name = ['custom_1', None, 'custom_2', 'custom_3', None]
     ex_run_order = list(range(1, 6))
@@ -62,7 +62,7 @@ def test_check_unnamed_fovs():
     ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
     # test that missing names are given a placeholder
-    rf.check_unnamed_fovs(ex_run)
+    rf.rename_missing_fovs(ex_run)
     for fov in ex_run.get('fovs', ()):
         assert fov.get('name') is not None
 

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -2,20 +2,17 @@ import tempfile
 import json
 import os
 import pytest
-import pandas as pd
 
-# from ark.utils import test_utils
 from ark.utils import io_utils
 from toffy import rename_fovs as rf
 
 
-def create_sample_run(data, create_json=False, bad=False):
+def create_sample_run(name_list, run_order_list, scan_count_list, create_json=False, bad=False):
     fov_list = []
     sample_run = {"fovs": fov_list}
 
     # set up dictionary
-    for name, run_order, scan_count in \
-            zip(data.loc[:, "names"], data.loc[:, "run"], data.loc[:, "scans"]):
+    for name, run_order, scan_count in zip(name_list, run_order_list, scan_count_list):
         ex_fov = {
             "scanCount": scan_count,
             "runOrder": run_order,
@@ -57,14 +54,12 @@ def remove_fov_dirs(base_dir):
 
 def test_check_unnamed_fovs():
     # data with missing names
-    ex_data = pd.DataFrame(
-        {'names': ['MoQC', None, 'tonsil_bottom', 'moly_qc_tissue', None],
-         'run': list(range(1, 6)),
-         'scans': list(range(1, 6))
-         })
+    ex_name = ['custom_1', None, 'custom_2', 'custom_3', None]
+    ex_run_order = list(range(1, 6))
+    ex_scan_count = list(range(1, 6))
 
     # create a dict with the sample data
-    ex_run = create_sample_run(ex_data)
+    ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
     # test that missing names are given a placeholder
     rf.check_unnamed_fovs(ex_run)
@@ -90,24 +85,22 @@ def test_rename_fov_dirs():
             rf.rename_fov_dirs(run_dir, fov_dir, not_new_dir)
 
         # regular sample run data
-        ex_data = pd.DataFrame(
-            {'names': ['MoQC', 'tonsil_bottom', 'moly_qc_tissue'],
-             'run': list(range(1, 4)),
-             'scans': [1, 2, 1]
-             })
+        ex_name = ['custom_1', 'custom_2', 'custom_3']
+        ex_run_order = list(range(1, 4))
+        ex_scan_count = [1, 2, 1]
 
         # create a json path with the sample data
-        ex_run_path = create_sample_run(ex_data, True)
+        ex_run_path = create_sample_run(ex_name, ex_run_order, ex_scan_count, True)
 
         # bad sample run data
-        bad_run = create_sample_run(ex_data, True, bad=True)
+        bad_run = create_sample_run(ex_name, ex_run_order, ex_scan_count, True, bad=True)
 
         # bad run file data should raise an error
         with pytest.raises(KeyError):
             rf.rename_fov_dirs(bad_run, fov_dir)
 
         # create already renamed fov folders
-        renamed_fovs = ['MoQC', 'tonsil_bottom-1', 'tonsil_bottom-2', 'moly_qc_tissue']
+        renamed_fovs = ['custom_1', 'custom_2-1', 'custom_2-2', 'custom_3']
         create_sample_fov_dirs(renamed_fovs, fov_dir)
 
         # fov folders already renamed should raise an error
@@ -134,7 +127,7 @@ def test_rename_fov_dirs():
         less_fovs = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-3-scan-1']
         create_sample_fov_dirs(less_fovs, fov_dir)
 
-        # fov folders already renamed should raise an error
+        # fovs in rule file without an existing dir should raise an error
         with pytest.warns(UserWarning, match="Not all FOVs"):
             rf.rename_fov_dirs(ex_run_path, fov_dir)
         remove_fov_dirs(fov_dir)
@@ -144,7 +137,7 @@ def test_rename_fov_dirs():
                       'fov-3-scan-1', 'fov-3-scan-3']
         create_sample_fov_dirs(extra_fovs, fov_dir)
 
-        # fov folders already renamed should raise an error
+        # extra dirs not listed in run file should raise an error
         with pytest.raises(ValueError, match="not found in run file"):
             rf.rename_fov_dirs(ex_run_path, fov_dir)
         remove_fov_dirs(fov_dir)

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -37,7 +37,6 @@ def create_sample_run(data, create_json=False, bad=False):
     if create_json:
         temp = tempfile.NamedTemporaryFile(mode="w", delete=False)
         json.dump(sample_run, temp)
-        print(temp.name)
         return temp.name
 
     return sample_run
@@ -83,8 +82,8 @@ def test_rename_fov_dirs():
         fov_dir = os.path.join(base_dir, 'fov_folder')
 
         # create existing new directory
-        os.mkdir(os.path.join(base_dir, 'not_new_directory'))
         not_new_dir = os.path.join(base_dir, 'not_new_directory')
+        os.mkdir(not_new_dir)
 
         # existing directory for new_dir should raise an error
         with pytest.raises(ValueError, match="already exists"):
@@ -122,10 +121,13 @@ def test_rename_fov_dirs():
 
         # test successful renaming to new dir
         rf.rename_fov_dirs(ex_run_path, fov_dir, os.path.join(base_dir, 'new_directory'))
-        remove_fov_dirs(os.path.join(base_dir, 'new_directory'))
+        new_dir = os.path.join(base_dir, 'new_directory')
+        assert set(io_utils.list_folders(new_dir)) == set(renamed_fovs)
+        remove_fov_dirs(new_dir)
 
         # test successful renaming
         rf.rename_fov_dirs(ex_run_path, fov_dir)
+        assert set(io_utils.list_folders(fov_dir)) == set(renamed_fovs)
         remove_fov_dirs(fov_dir)
 
         # create not enough fov folders

--- a/toffy/rename_fovs_test.py
+++ b/toffy/rename_fovs_test.py
@@ -62,7 +62,7 @@ def test_rename_missing_fovs():
     ex_run = create_sample_run(ex_name, ex_run_order, ex_scan_count)
 
     # test that missing names are given a placeholder
-    rf.rename_missing_fovs(ex_run)
+    ex_run = rf.rename_missing_fovs(ex_run)
     for fov in ex_run.get('fovs', ()):
         assert fov.get('name') is not None
 

--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -17,7 +17,7 @@ import warnings
 
 from dataclasses import dataclass
 
-from toffy import settings
+from toffy import settings, rename_fovs
 from ark.utils import misc_utils
 
 
@@ -357,6 +357,7 @@ def set_tiled_region_params(region_corners_path):
     # read in the region corners data
     with open(region_corners_path, 'r', encoding='utf-8') as flf:
         tiled_region_corners = json.load(flf)
+    tiled_region_corners = rename_fovs.rename_missing_fovs(tiled_region_corners)
 
     # define the parameter dict to return
     tiling_params = {}
@@ -666,6 +667,7 @@ def generate_tma_fov_list(tma_corners_path, num_fov_row, num_fov_col):
     # read in tma_corners_path
     with open(tma_corners_path, 'r', encoding='utf-8') as flf:
         tma_corners = json.load(flf)
+    tma_corners = rename_fovs.rename_missing_fovs(tma_corners)
 
     # a TMA can only be defined by four FOVs, one for each corner
     if len(tma_corners['fovs']) != 4:


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #72.
Closes #10.
Renames the FOV subdirectories which are currently specified by both a FOV and scan number. Also gives the option so specify a new directory name to copy subdirectories to and edit those, leaving the originals intact.

**How did you implement your changes**

In file **rename_fovs.py** I set up the function `rename_fov_dirs(run_path, fov_dir, new_dir=None)` which takes in a path to the run JSON file, the path to directory storing all the FOV subdirectories, and a new directory name (string) if desired. FOV name and scan count are read from the JSON file and stored as keys and values in `fov_scan`. The names of current subfolders are retrieved via `io_utils.listfolders()` and then sorted to ensure they're sorted alphabetically and numerically. An error is raised the expected number of folders based on the run file does not match the number of folders in the provided `fov_dir`. 

**Remaining issues**

I was hoping to have some kind of validation step ensuring all FOV names pulled were correct. Is there a master list of all possible FOVs to use? Still working on possible tests. Also will need some direction on where exactly to implement the function. 