### PR TITLE
Rosetta modifications

### DIFF
--- a/templates/4_compensate_image_data.ipynb
+++ b/templates/4_compensate_image_data.ipynb
@@ -110,10 +110,11 @@
     "panel = pd.read_csv(os.path.join(base_dir, panel_file_name))\n",
     "\n",
     "# extract the bin files\n",
-    "bin_files.extract_bin_files(test_bin_dir, img_out_dir, panel=panel, intensities=['Au'])\n",
+    "bin_files.extract_bin_files(test_bin_dir, img_out_dir, panel=panel, intensities=['Au', 'chan_39'])\n",
     "\n",
-    "# replace gold count image with gold intensity image\n",
+    "# replace count images with intensity images\n",
     "rosetta.replace_with_intensity_image(run_dir=img_out_dir, channel='Au')\n",
+    "rosetta.replace_with_intensity_image(run_dir=img_out_dir, channel='chan_39')\n",
     "\n",
     "# clean up dirs\n",
     "rosetta.remove_sub_dirs(run_dir=img_out_dir, sub_dirs=['intensities', 'intensity_times_width'])\n",
@@ -138,7 +139,7 @@
    "source": [
     "### Now that we've generated the image data, we can test out different values for the compensation matrix. We'll be testing out coefficients in proportion to their value in the default matrix. For example, specifying multipliers of 0.5, 1, and 2 would test coefficients that are half the size, the same size, and twice the size of the coefficients in the default matrix, respectively. \n",
     "\n",
-    "### The cell below can be run multiple times to hone in on the speficic coefficient that works the best."
+    "### The cell below can be run multiple times to hone in on the speficic coefficient that works the best. In general, it is best to optimize the value of one channel's coefficient at a time. The channels that often need to be optimized are Au and Noodle. However, you can optimize the coefficient for any channel that causes problems"
    ]
   },
   {
@@ -148,14 +149,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# set multipliers\n",
-    "multipliers = [0.5, 1, 2]\n",
+    "# Pick the channel that you will be optimizing the coefficient for\n",
+    "current_channel_name = 'Au'\n",
+    "current_channel_mass = rosetta.get_masses_from_channel_names([current_channel_name], panel)\n",
     "\n",
-    "# If you only want to look at the output for a subset of the masses once you've picked good coefficients for the rest, update this variable\n",
-    "output_masses = None # e.g. output_masses = [146, 150]\n",
+    "# set multipliers\n",
+    "multipliers = [0.25, 1, 4]\n",
+    "\n",
+    "# If you only want to look at the output for a subset of the channels once you've picked good coefficients for the rest, update this variable for faste processing.\n",
+    "# Otherwise, all channels will be compensated and saved\n",
+    "output_channel_names = None # e.g. output_channel_names = ['Au', 'CD45', 'PanCK']\n",
+    "\n",
+    "# pick an informative name\n",
+    "folder_name = 'give_a_name_for_this_folder'\n",
+    "\n",
+    "# everything from here and below will run automatically\n",
+    "if output_channel_names is not None:\n",
+    "    output_masses = rosetta.get_masses_from_channel_names(output_channel_names, panel)\n",
+    "else:\n",
+    "    output_masses = None\n",
     "\n",
     "# create sub-folder to hold images and files from this set of multipliers\n",
-    "folder_name = 'give_a_name_for_this_folder'\n",
     "folder_path = os.path.join(base_dir, folder_name)\n",
     "if os.path.exists(folder_path):\n",
     "    raise ValueError('This folder {} already exists, please' \n",
@@ -165,7 +179,7 @@
     "\n",
     "# generate rosseta matrices for each multiplier\n",
     "rosetta.create_rosetta_matrices(default_matrix=os.path.join(base_dir, 'commercial_rosetta_matrix.csv'),\n",
-    "                               multipliers=multipliers, masses=[197, 117],\n",
+    "                               multipliers=multipliers, masses=current_channel_mass,\n",
     "                               save_dir=folder_path)\n",
     "\n",
     "# loop over each multiplier and compensate the data\n",
@@ -184,7 +198,7 @@
    "id": "1e0c72cb",
    "metadata": {},
    "source": [
-    "### Now that we've generated the compensated data for the given multipliers, we'll generate stitched images to make comparing the different multipliers easier. In general, we find that modifications usually only need to be made to the Noodle channel and the gold (Au) channel. However, if the coefficients for other interactions need to be adjusted, feel free to do so. You can add additional channels in the for loop below to view more comparisons"
+    "### Now that we've generated the compensated data for the given multipliers, we'll generate stitched images to make comparing the different multipliers easier"
    ]
   },
   {
@@ -198,14 +212,13 @@
     "stitched_dir = os.path.join(folder_path, 'stitched_images')\n",
     "os.makedirs(stitched_dir)\n",
     "\n",
-    "rosetta.create_tiled_comparison(input_dir_list=rosetta_dirs, output_dir=stitched_dir)\n",
+    "rosetta.create_tiled_comparison(input_dir_list=rosetta_dirs, output_dir=stitched_dir, channels=output_channel_names)\n",
     "\n",
-    "# add the noodle channel and gold channel as first row to make evaluation easier\n",
-    "for channel in ['Au', 'Noodle']:\n",
-    "    output_dir = os.path.join(folder_path, 'stitched_with_' + channel)\n",
-    "    os.makedirs(output_dir)\n",
-    "    rosetta.add_source_channel_to_tiled_image(raw_img_dir=img_out_dir, tiled_img_dir=stitched_dir,\n",
-    "                                             output_dir=output_dir, source_channel=channel)"
+    "# add the source channel as first row to make evaluation easier\n",
+    "output_dir = os.path.join(folder_path, 'stitched_with_' + current_channel_name)\n",
+    "os.makedirs(output_dir)\n",
+    "rosetta.add_source_channel_to_tiled_image(raw_img_dir=img_out_dir, tiled_img_dir=stitched_dir,\n",
+    "                                             output_dir=output_dir, source_channel=current_channel_name)"
    ]
   },
   {
@@ -213,7 +226,7 @@
    "id": "7b2274b4",
    "metadata": {},
    "source": [
-    "### There will now be a folder named *stitched_with_Au* and *stitched_with_Noodle* present within the sub-folder you created. You can look through these stitched images, one for each channel, to determine whether the multiplier needs to be higher, lower, or the same.\n",
+    "### There will now be a folder named *stitched_with_channel_name* present within the sub-folder you created. You can look through these stitched images to determine whether the multiplier needs to be higher, lower, or the same.\n",
     "\n",
     "### For each channel, pick the multiplier that worked the best. Then, open the commercial_rosetta_matrix.csv file that you copied over and update the corresponding coefficient in that cell to be the `previous_value * coefficient`. If you're happy with the new coefficients, you can take your modified matrix and move on to the next step. If not, you can rerun the two cells above starting with the updated coefficients to further narrow in on the best value. Once you've finalized your coefficients, please let us know [here](https://github.com/angelolab/toffy/issues/55)."
    ]

--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -284,10 +284,10 @@ def create_tiled_comparison(input_dir_list, output_dir, img_sub_folder='normaliz
 
             # go through each of the directories, read in the images, and place in the right spot
             for idx, key in enumerate(input_dir_list):
-                dir_data = load_imgs_from_tree(key, channels=channels,
+                dir_data = load_imgs_from_tree(key, channels=channels[j:j + 1],
                                                img_sub_folder=img_sub_folder)
                 tiled_image[(img_size * idx):(img_size * (idx + 1)), start:end] = \
-                    dir_data.values[i, :, :, j]
+                    dir_data.values[i, :, :, 0]
 
         io.imsave(os.path.join(output_dir, channels[j] + '_comparison.tiff'),
                   tiled_image, check_contrast=False)

--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -288,23 +288,19 @@ def compensate_image_data(raw_data_dir, comp_data_dir, comp_mat_path, panel_info
 
 
 def create_tiled_comparison(input_dir_list, output_dir, img_sub_folder='normalized',
-                            channel_subset_dir=None):
+                            channels=None):
     """Creates a tiled image comparing FOVs from all supplied runs for each channel.
 
     Args:
         input_dir_list: list of directories to compare
         output_dir: directory where tifs will be saved
         img_sub_folder: subfolder within each input directory to load images from
-        channel_subset_dir: directory with a subset of the channels contained in other directories.
-            Only channels found in this directory will be used for tiling."""
+        channels: list of channels to compare. """
 
-    # Get list of channels from specific directory if provided, otherwise use the first one
-    if channel_subset_dir is None:
-        channel_subset_dir = input_dir_list[0]
-
-    test_fov = list_folders(channel_subset_dir)[0]
-    test_data = load_imgs_from_tree(data_dir=channel_subset_dir, fovs=[test_fov],
-                                    img_sub_folder=img_sub_folder)
+    test_dir = input_dir_list[0]
+    test_fov = list_folders(test_dir)[0]
+    test_data = load_imgs_from_tree(data_dir=test_dir, fovs=[test_fov],
+                                    img_sub_folder=img_sub_folder, channels=channels)
 
     img_size = test_data.shape[1]
     channels = test_data.channels.values

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -250,17 +250,18 @@ def test_create_tiled_comparison(dir_num):
             col_len = dir_num * 10
             assert chan_img.shape == (col_len, row_len)
 
-        # check that directories with different images raises error
+        # check that directories with different images are okay if appropriately specified
         for i in range(num_fovs):
-            os.remove(os.path.join(top_level_dir, dir_names[0], 'fov{}'.format(i),
+            os.remove(os.path.join(top_level_dir, dir_names[1], 'fov{}'.format(i),
                                    'normalized/chan0.tiff'))
-        with pytest.raises(ValueError):
-            rosetta.create_tiled_comparison(paths, output_dir)
 
         # no error raised if subset directory is specified
         rosetta.create_tiled_comparison(paths, output_dir,
                                         channel_subset_dir=os.path.join(top_level_dir,
-                                                                        dir_names[0]))
+                                                                        dir_names[1]))
+        # but one is raised if no subset directory is specified
+        with pytest.raises(ValueError, match='1 of 1'):
+            rosetta.create_tiled_comparison(paths, output_dir)
 
 
 def test_add_source_channel_to_tiled_image():

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -257,6 +257,11 @@ def test_create_tiled_comparison(dir_num):
         with pytest.raises(ValueError):
             rosetta.create_tiled_comparison(paths, output_dir)
 
+        # no error raised if subset directory is specified
+        rosetta.create_tiled_comparison(paths, output_dir,
+                                        channel_subset_dir=os.path.join(top_level_dir,
+                                                                        dir_names[0]))
+
 
 def test_add_source_channel_to_tiled_image():
     with tempfile.TemporaryDirectory() as top_level_dir:
@@ -394,3 +399,11 @@ def test_create_rosetta_matrices():
 
             rescaled = test_matrix.divide(mult_vec, axis='index')
             assert np.array_equal(base_rosetta, rescaled)
+
+        # check that error is raised when non-numeric rosetta_matrix is passed
+        bad_matrix = pd.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6], 'col3': ['a', 'b', 'c']})
+        bad_matrix_path = os.path.join(temp_dir, 'bad_rosetta_matrix.csv')
+        bad_matrix.to_csv(bad_matrix_path)
+
+        with pytest.raises(ValueError, match='include only numeric'):
+            create_rosetta_matrices(bad_matrix_path, temp_dir, multipliers)

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -275,15 +275,14 @@ def test_create_tiled_comparison(dir_num):
             col_len = dir_num * 10
             assert chan_img.shape == (col_len, row_len)
 
-        # check that directories with different images are okay if appropriately specified
+        # check that directories with different images are okay if overlapping channels specified
         for i in range(num_fovs):
             os.remove(os.path.join(top_level_dir, dir_names[1], 'fov{}'.format(i),
                                    'normalized/chan0.tiff'))
 
         # no error raised if subset directory is specified
-        rosetta.create_tiled_comparison(paths, output_dir,
-                                        channel_subset_dir=os.path.join(top_level_dir,
-                                                                        dir_names[1]))
+        rosetta.create_tiled_comparison(paths, output_dir, channels=['chan1', 'chan2'])
+
         # but one is raised if no subset directory is specified
         with pytest.raises(ValueError, match='1 of 1'):
             rosetta.create_tiled_comparison(paths, output_dir)

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -160,6 +160,30 @@ def test_validate_inputs():
             rosetta.validate_inputs(**input_dict_gaus_rad)
 
 
+def test_flat_field_correction():
+    input_img = np.random.rand(10, 10)
+    corrected_img = rosetta.flat_field_correction(img=input_img)
+
+    assert corrected_img.shape == input_img.shape
+    assert not np.array_equal(corrected_img, input_img)
+
+
+def test_get_masses_from_channel_names():
+    targets = ['chan1', 'chan2', 'chan3']
+    masses = [1, 2, 3]
+    test_df = pd.DataFrame({'Target': targets,
+                            'Mass': masses})
+
+    all_masses = rosetta.get_masses_from_channel_names(targets, test_df)
+    assert np.array_equal(masses, all_masses)
+
+    subset_masses = rosetta.get_masses_from_channel_names(targets[:2], test_df)
+    assert np.array_equal(masses[:2], subset_masses)
+
+    with pytest.raises(ValueError, match='channel names'):
+        rosetta.get_masses_from_channel_names(['chan4'], test_df)
+
+
 @parametrize('output_masses', [None, [25, 50, 101], [25, 50]])
 @parametrize('input_masses', [None, [25, 50, 101], [25, 50]])
 @parametrize('gaus_rad', [0, 1, 2])
@@ -187,7 +211,8 @@ def test_compensate_image_data(output_masses, input_masses, gaus_rad, save_forma
         # call function
         rosetta.compensate_image_data(data_dir, output_dir, comp_mat_path, panel_info,
                                       input_masses=input_masses, output_masses=output_masses,
-                                      save_format=save_format, gaus_rad=gaus_rad)
+                                      save_format=save_format, gaus_rad=gaus_rad,
+                                      ffc_channels=['chan1'])
 
         # all folders created
         output_folders = list_folders(output_dir)


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Updates the rosetta workflow for improved usability and speed. 

**How did you implement your changes**

1. Reorganized the notebook to emphasize changing only a single source channel at a time, rather than both Noodle and Au, as this was the approach I took. 
2. Add flat field correction for mass 39 to remove gradient across the image
3. adds a helper function `get_masses_from_channel_names` to allow the user to specify channel names rather than masses
4. Reorganize `create_tiled_comparison` to only read in data for one channel at a time, which results in significant speedup

**Remaining issues**
Once Hadeesha has finished testing his coefficients, we'll transition this notebook to evaluation purposes only. This will basically be a simple interface to making a stitched comparison of a pre- and post-rosetta. We'll hide the stuff about changing rosetta to emphasize that the defaults should work quite well for everyone
