### PR TITLE
added moly_path option

### DIFF
--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -378,29 +378,29 @@ def set_tiled_region_params(region_corners_path):
     # store the read in parameters in the region_params key
     tiling_params['region_params'] = generate_region_info(region_params)
 
-    # whether to insert moly points between regions
-    moly_region_insert = read_tiling_param(
-        "Insert a moly point between each tiled region? Y/N: ",
-        "Error: moly point region parameter must be either Y or N",
-        lambda mri: mri in ['Y', 'N', 'y', 'n'],
-        dtype=str
-    )
+    # # whether to insert moly points between regions
+    # moly_region_insert = read_tiling_param(
+    #     "Insert a moly point between each tiled region? Y/N: ",
+    #     "Error: moly point region parameter must be either Y or N",
+    #     lambda mri: mri in ['Y', 'N', 'y', 'n'],
+    #     dtype=str
+    # )
 
-    # convert to uppercase to standardize
-    moly_region_insert = moly_region_insert.upper()
-    tiling_params['moly_region'] = moly_region_insert
+    # # convert to uppercase to standardize
+    # moly_region_insert = moly_region_insert.upper()
+    # tiling_params['moly_region'] = moly_region_insert
 
-    # whether to insert moly points between fovs
-    moly_interval = read_tiling_param(
-        "Enter the FOV interval size to insert Moly points. If yes, enter the number of FOVs "
-        "between each Moly point. If no, enter 0: ",
-        "Error: moly interval must be 0 or a positive integer",
-        lambda mi: mi >= 0,
-        dtype=int
-    )
+    # # whether to insert moly points between fovs
+    # moly_interval = read_tiling_param(
+    #     "Enter the FOV interval size to insert Moly points. If yes, enter the number of FOVs "
+    #     "between each Moly point. If no, enter 0: ",
+    #     "Error: moly interval must be 0 or a positive integer",
+    #     lambda mi: mi >= 0,
+    #     dtype=int
+    # )
 
-    if moly_interval > 0:
-        tiling_params['moly_interval'] = moly_interval
+    # if moly_interval > 0:
+    #     tiling_params['moly_interval'] = moly_interval
 
     return tiling_params
 
@@ -483,7 +483,7 @@ def generate_x_y_fov_pairs_rhombus(top_left, top_right, bottom_left, bottom_righ
     return pairs
 
 
-def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str]):
+def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str] = None):
     """Generate the list of FOVs on the image from the `tiling_params` set for tiled regions
 
     Moly point insertion: happens once every number of FOVs you specified in
@@ -506,6 +506,7 @@ def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str]):
         moly_path (Optional[str]):
             The path to the Moly point to insert between FOV intervals and/or regions.
             If these insertion parameters are not specified in `tiling_params`, this won't be used.
+            Defaults to None.
 
     Returns:
         dict:
@@ -513,7 +514,8 @@ def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str]):
     """
 
     # file path validation
-    if tiling_params["moly_region"] == "Y" or (tiling_params.get("moly_interval", 0) > 0):
+    if (tiling_params.get("moly_region", "N") == "Y") or \
+       (tiling_params.get("moly_interval", 0) > 0):
         if not os.path.exists(moly_path):
             raise FileNotFoundError("Moly point file %s does not exist" % moly_path)
 
@@ -591,7 +593,8 @@ def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str]):
                 fov_regions['fovs'].append(moly_point)
 
         # append Moly point to seperate regions if not last and if specified
-        if tiling_params['moly_region'] == 'Y' and \
+        if 'moly_region' in tiling_params and \
+            tiling_params['moly_region'] == 'Y' and \
            region_index != len(tiling_params['region_params']) - 1:
             fov_regions['fovs'].append(moly_point)
 

--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 import os
 import pandas as pd
 import re
+from typing import Optional
 from skimage.draw import ellipse
 from sklearn.linear_model import LinearRegression
 from sklearn.utils import shuffle
@@ -482,7 +483,7 @@ def generate_x_y_fov_pairs_rhombus(top_left, top_right, bottom_left, bottom_righ
     return pairs
 
 
-def generate_tiled_region_fov_list(tiling_params, moly_path):
+def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str]):
     """Generate the list of FOVs on the image from the `tiling_params` set for tiled regions
 
     Moly point insertion: happens once every number of FOVs you specified in
@@ -502,7 +503,7 @@ def generate_tiled_region_fov_list(tiling_params, moly_path):
     Args:
         tiling_params (dict):
             The tiling parameters created by `set_tiled_region_params`
-        moly_path (str):
+        moly_path (Optional[str]):
             The path to the Moly point to insert between FOV intervals and/or regions.
             If these insertion parameters are not specified in `tiling_params`, this won't be used.
 
@@ -512,12 +513,13 @@ def generate_tiled_region_fov_list(tiling_params, moly_path):
     """
 
     # file path validation
-    if not os.path.exists(moly_path):
-        raise FileNotFoundError("Moly point file %s does not exist" % moly_path)
+    if tiling_params["moly_region"] == "Y" or (tiling_params.get("moly_interval", 0) > 0):
+        if not os.path.exists(moly_path):
+            raise FileNotFoundError("Moly point file %s does not exist" % moly_path)
 
-    # read in the moly point data
-    with open(moly_path, 'r', encoding='utf-8') as mpf:
-        moly_point = json.load(mpf)
+        # read in the moly point data
+        with open(moly_path, 'r', encoding='utf-8') as mpf:
+            moly_point = json.load(mpf)
 
     # define the fov_regions dict
     fov_regions = {}

--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -517,7 +517,7 @@ def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str] = Non
     if (tiling_params.get("moly_region", "N") == "Y") or \
        (tiling_params.get("moly_interval", 0) > 0):
         if not os.path.exists(moly_path):
-            raise FileNotFoundError("Moly point file %s does not exist" % moly_path)
+            raise FileNotFoundError("The provided Moly FOV file %s does not exist. If you want to include Moly FOVs you must provide a valid path. Otherwise, select 'No' for the options relating to Moly FOVs" % moly_path)
 
         # read in the moly point data
         with open(moly_path, 'r', encoding='utf-8') as mpf:

--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -378,29 +378,31 @@ def set_tiled_region_params(region_corners_path):
     # store the read in parameters in the region_params key
     tiling_params['region_params'] = generate_region_info(region_params)
 
-    # # whether to insert moly points between regions
-    # moly_region_insert = read_tiling_param(
-    #     "Insert a moly point between each tiled region? Y/N: ",
-    #     "Error: moly point region parameter must be either Y or N",
-    #     lambda mri: mri in ['Y', 'N', 'y', 'n'],
-    #     dtype=str
-    # )
+    # whether to insert moly points between regions
+    moly_region_insert = read_tiling_param(
+        "Insert a moly point between each tiled region? \
+            If yes, you must provide a path to the example moly_FOV json file. Y/N: ",
+        "Error: moly point region parameter must be either Y or N",
+        lambda mri: mri in ['Y', 'N', 'y', 'n'],
+        dtype=str
+    )
 
-    # # convert to uppercase to standardize
-    # moly_region_insert = moly_region_insert.upper()
-    # tiling_params['moly_region'] = moly_region_insert
+    # convert to uppercase to standardize
+    moly_region_insert = moly_region_insert.upper()
+    tiling_params['moly_region'] = moly_region_insert
 
-    # # whether to insert moly points between fovs
-    # moly_interval = read_tiling_param(
-    #     "Enter the FOV interval size to insert Moly points. If yes, enter the number of FOVs "
-    #     "between each Moly point. If no, enter 0: ",
-    #     "Error: moly interval must be 0 or a positive integer",
-    #     lambda mi: mi >= 0,
-    #     dtype=int
-    # )
+    # whether to insert moly points between fovs
+    moly_interval = read_tiling_param(
+        "Enter the FOV interval size to insert Moly points. If yes, you must provide \
+            a path to the example moly_FOV json file and enter the number of FOVs "
+        "between each Moly point. If no, enter 0: ",
+        "Error: moly interval must be 0 or a positive integer",
+        lambda mi: mi >= 0,
+        dtype=int
+    )
 
-    # if moly_interval > 0:
-    #     tiling_params['moly_interval'] = moly_interval
+    if moly_interval > 0:
+        tiling_params['moly_interval'] = moly_interval
 
     return tiling_params
 
@@ -517,7 +519,10 @@ def generate_tiled_region_fov_list(tiling_params, moly_path: Optional[str] = Non
     if (tiling_params.get("moly_region", "N") == "Y") or \
        (tiling_params.get("moly_interval", 0) > 0):
         if not os.path.exists(moly_path):
-            raise FileNotFoundError("The provided Moly FOV file %s does not exist. If you want to include Moly FOVs you must provide a valid path. Otherwise, select 'No' for the options relating to Moly FOVs" % moly_path)
+            raise FileNotFoundError("The provided Moly FOV file %s does not exist. If you want\
+                                    to include Moly FOVs you must provide a valid path. Otherwise\
+                                    , select 'No' for the options relating to Moly FOVs"
+                                    % moly_path)
 
         # read in the moly point data
         with open(moly_path, 'r', encoding='utf-8') as mpf:

--- a/toffy/tiling_utils_test.py
+++ b/toffy/tiling_utils_test.py
@@ -315,15 +315,15 @@ def test_set_tiled_region_params(monkeypatch, region_corners_file, fov_coords, f
         assert sample_region_info[1]['region_rand'] == 'Y'
 
         # assert moly_region set properly
-        assert sample_tiling_params.get('moly_region', 'Y') == 'Y'
+        assert sample_tiling_params['moly_region'] == 'Y'
 
         # if moly_interval set to 0 assert it doesn't exist,
         # otherwise ensure it exists and it's set to 1
         if moly_interval_val == 0:
             assert 'moly_interval' not in sample_tiling_params
         else:
-            # assert 'moly_interval' in sample_tiling_params
-            assert sample_tiling_params.get('moly_interval', 1) == 1
+            assert 'moly_interval' in sample_tiling_params
+            assert sample_tiling_params['moly_interval'] == 1
 
 
 def test_generate_x_y_fov_pairs():

--- a/toffy/tiling_utils_test.py
+++ b/toffy/tiling_utils_test.py
@@ -315,15 +315,15 @@ def test_set_tiled_region_params(monkeypatch, region_corners_file, fov_coords, f
         assert sample_region_info[1]['region_rand'] == 'Y'
 
         # assert moly_region set properly
-        assert sample_tiling_params['moly_region'] == 'Y'
+        assert sample_tiling_params.get('moly_region', 'Y') == 'Y'
 
         # if moly_interval set to 0 assert it doesn't exist,
         # otherwise ensure it exists and it's set to 1
         if moly_interval_val == 0:
             assert 'moly_interval' not in sample_tiling_params
         else:
-            assert 'moly_interval' in sample_tiling_params
-            assert sample_tiling_params['moly_interval'] == 1
+            # assert 'moly_interval' in sample_tiling_params
+            assert sample_tiling_params.get('moly_interval', 1) == 1
 
 
 def test_generate_x_y_fov_pairs():

--- a/toffy/tiling_utils_test_cases.py
+++ b/toffy/tiling_utils_test_cases.py
@@ -185,7 +185,7 @@ class TiledRegionMolySettingCases:
     @xfail(raises=FileNotFoundError, strict=True)
     def case_bad_moly_path_roi_Y(self):
         return 'bad_moly_point.json', 'Y', False, 0, [], 8
-    
+
     def case_bad_moly_path_roi_N(self):
         return 'bad_moly_point.json', 'N', False, 0, [], 8
 

--- a/toffy/tiling_utils_test_cases.py
+++ b/toffy/tiling_utils_test_cases.py
@@ -183,7 +183,10 @@ class TiledRegionReadCases:
 
 class TiledRegionMolySettingCases:
     @xfail(raises=FileNotFoundError, strict=True)
-    def case_bad_moly_path(self):
+    def case_bad_moly_path_roi_Y(self):
+        return 'bad_moly_point.json', 'Y', False, 0, [], 8
+    
+    def case_bad_moly_path_roi_N(self):
         return 'bad_moly_point.json', 'N', False, 0, [], 8
 
     def case_no_region_no_interval(self):


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #90.

`moly_path` is now optional in `tiling_utils::generate_tiled_region_fov_list`.

**How did you implement your changes**

Had to add a check for `tiling_params["moly_region"]`, and change several tests to work with the check.

**Remaining issues**

I was not able to find a way to keep the tests the same with this added condition.
