### PR TITLE
update toffy to use mini-bin-tools v0.2.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/angelolab/ark-analysis.git@v0.3.2
-    - git+https://github.com/angelolab/mibi-bin-tools.git@v0.2.2
+    - git+https://github.com/angelolab/mibi-bin-tools.git@v0.2.3
     - jupyter>=1.0.0,<2
     - jupyter_contrib_nbextensions>=0.5.1,<1
     - jupyterlab>=3.4.3,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ark-analysis @ git+https://github.com/angelolab/ark-analysis.git@v0.3.2
-mibi-bin-tools @ git+https://github.com/angelolab/mibi-bin-tools.git@v0.2.2
+mibi-bin-tools @ git+https://github.com/angelolab/mibi-bin-tools.git@v0.2.3
 jupyter>=1.0.0,<2
 jupyter_contrib_nbextensions>=0.5.1,<1
 jupyterlab>=3.4.3,<4


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Updates requirements.txt and environment.yml to use latest mibi-bin-tools version.

