### PR TITLE
run fovs in numerical order

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ natsort>=0.8
 numpy>=1.22,<2
 watchdog>=2.1.6,<3
 traitlets>= 5.2.2
-natsort>= 0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ natsort>=0.8
 numpy>=1.22,<2
 watchdog>=2.1.6,<3
 traitlets>=5.2.2
+natsort

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ jupyterlab>=3.4.3,<4
 natsort>=0.8
 numpy>=1.22,<2
 watchdog>=2.1.6,<3
-traitlets>=5.2.2
-natsort
+traitlets>= 5.2.2
+natsort>= 0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ jupyterlab>=3.4.3,<4
 natsort>=0.8
 numpy>=1.22,<2
 watchdog>=2.1.6,<3
-traitlets>= 5.2.2
+traitlets>=5.2.2

--- a/templates/3b_extract_images_from_bin.ipynb
+++ b/templates/3b_extract_images_from_bin.ipynb
@@ -24,6 +24,7 @@
     "sys.path.append('../')\n",
     "\n",
     "import os\n",
+    "import pandas as pd\n",
     "\n",
     "from toffy.bin_extraction import extract_missing_fovs\n",
     "from mibi_bin_tools import bin_files, io_utils"

--- a/templates/3c_generate_qc_metrics.ipynb
+++ b/templates/3c_generate_qc_metrics.ipynb
@@ -30,8 +30,9 @@
    "source": [
     "from datetime import datetime as dt\n",
     "import os\n",
-    "import pandas as pd\n",
     "import re\n",
+    "import pandas as pd\n",
+    "import natsort as ns\n",
     "\n",
     "from mibi_bin_tools import bin_files\n",
     "from toffy import qc_comp\n",
@@ -131,7 +132,7 @@
     "\n",
     "# run QC metric extraction on each fov that doesn't have QC metric files defined\n",
     "# saves directly to bin_file_path\n",
-    "for fov in fovs:\n",
+    "for fov in ns.natsorted(fovs):\n",
     "    # NOTE: if nonzero_mean_stats.csv doesn't exist, the other QC metric .csv paths also don't exist\n",
     "    if not os.path.exists(os.path.join(bin_file_path, '%s_nonzero_mean_stats.csv' % fov)):\n",
     "        print(\"Extracting QC metrics for fov %s\" % fov)\n",
@@ -301,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/templates/3d_compute_median_pulse_height.ipynb
+++ b/templates/3d_compute_median_pulse_height.ipynb
@@ -97,6 +97,7 @@
     "# saves individual .csv  files to mph_dir\n",
     "for fov in ns.natsorted(fovs):\n",
     "    if not os.path.exists(os.path.join(bin_file_dir, '%s-mph_pulse.csv' % fov)):\n",
+    "        print(\"Computing MPH for fov %s\" % fov)\n",
     "        mph_comp.compute_mph_metrics(bin_file_dir, mph_dir, fov, mass, mass_start, mass_stop)"
    ]
   },

--- a/templates/3d_compute_median_pulse_height.ipynb
+++ b/templates/3d_compute_median_pulse_height.ipynb
@@ -31,6 +31,7 @@
     "import os\n",
     "import shutil\n",
     "import pandas as pd\n",
+    "import natsort as ns\n",
     "\n",
     "from mibi_bin_tools import bin_files\n",
     "from toffy import mph_comp\n",
@@ -94,7 +95,7 @@
     "\n",
     "# retrieve the total counts and compute pulse heights for each FOV run file\n",
     "# saves individual .csv  files to mph_dir\n",
-    "for fov in fovs:\n",
+    "for fov in ns.natsorted(fovs):\n",
     "    if not os.path.exists(os.path.join(bin_file_dir, '%s-mph_pulse.csv' % fov)):\n",
     "        mph_comp.compute_mph_metrics(bin_file_dir, mph_dir, fov, mass, mass_start, mass_stop)"
    ]

--- a/toffy/bin_extraction.py
+++ b/toffy/bin_extraction.py
@@ -1,3 +1,5 @@
+import natsort as ns
+
 from toffy.json_utils import list_moly_fovs
 from mibi_bin_tools import bin_files, io_utils
 
@@ -26,6 +28,7 @@ def extract_missing_fovs(bin_file_dir, extraction_dir, panel, extract_intensitie
     # extract missing fovs to extraction_dir
     non_moly_fovs = list(set(fovs).difference(moly_fovs))
     missing_fovs = list(set(non_moly_fovs).difference(extracted_fovs))
+    missing_fovs = ns.natsorted(missing_fovs)
 
     if missing_fovs:
         bin_files.extract_bin_files(bin_file_dir, extraction_dir, include_fovs=missing_fovs,


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Currently, notebooks 3b-3d process the fovs according to their order in the run directory, which is not inherently in numerical order. (ex: fov-1-scan-1, fov-11-scan-1, fov-12-scan-1, ... , fov-2-scan-1, ... , fov-3-scan-1)
It is more intuitive when running these notebooks after a completed run to process them in order.

**How did you implement your changes**

Used `natsort.natsorted()` to order fov names numerically before extracting the tiffs / computing the qc and mph metrics.
Also adds a print statement to the MPH notebook so user can check the progress, similar to the qc notebook.

