### PR TITLE
Output float32 images for normalization notebook

### DIFF
--- a/templates/4b_normalize_image_data.ipynb
+++ b/templates/4b_normalize_image_data.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "c9751084-7855-4005-b152-55895ff40823",
    "metadata": {},
    "outputs": [],
@@ -55,7 +55,10 @@
     "bin_base_dir = 'D:\\\\Data'\n",
     "rosetta_base_dir = 'D:\\\\Rosetta_Compensated_Images'\n",
     "normalized_base_dir = 'D:\\\\Normalized_Images'\n",
-    "mph_base_dir = 'D:\\\\Data'"
+    "mph_base_dir = 'D:\\\\Data'\n",
+    "\n",
+    "# check the run for changes in detector voltage\n",
+    "normalize.check_detector_voltage(os.path.join(bin_base_dir, run_name))"
    ]
   },
   {
@@ -136,9 +139,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "toffy_env",
    "language": "python",
-   "name": "python3"
+   "name": "toffy_env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -150,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/toffy/normalize.py
+++ b/toffy/normalize.py
@@ -520,8 +520,8 @@ def normalize_fov(img_data, norm_vals, norm_dir, fov, channels, extreme_vals):
                       'recommended: {}'.format(fov, bad_channels))
 
     # correct images and save
+    norm_vals = norm_vals.astype(img_data.dtype)
     normalized_images = img_data / norm_vals.reshape((1, 1, 1, len(norm_vals)))
-    normalized_images = normalized_images.astype(np.float32)
 
     for idx, chan in enumerate(channels):
         io.imsave(os.path.join(output_fov_dir, chan + '.tiff'),

--- a/toffy/normalize.py
+++ b/toffy/normalize.py
@@ -521,6 +521,7 @@ def normalize_fov(img_data, norm_vals, norm_dir, fov, channels, extreme_vals):
 
     # correct images and save
     normalized_images = img_data / norm_vals.reshape((1, 1, 1, len(norm_vals)))
+    normalized_images = normalized_images.astype(np.float32)
 
     for idx, chan in enumerate(channels):
         io.imsave(os.path.join(output_fov_dir, chan + '.tiff'),

--- a/toffy/normalize_test.py
+++ b/toffy/normalize_test.py
@@ -370,8 +370,7 @@ def test_normalize_fov(tmpdir):
     # create image data
     fovs, chans = test_utils.gen_fov_chan_names(num_fovs=1, num_chans=3)
     _, data_xr = test_utils.create_paired_xarray_fovs(
-        tmpdir, fovs, chans, img_shape=(10, 10))
-    data_xr = data_xr.astype('float32')
+        tmpdir, fovs, chans, img_shape=(10, 10), dtype='float32')
 
     # create inputs
     norm_vals = np.random.rand(len(chans))

--- a/toffy/normalize_test.py
+++ b/toffy/normalize_test.py
@@ -386,6 +386,9 @@ def test_normalize_fov(tmpdir):
     norm_imgs = load_utils.load_imgs_from_tree(norm_dir, channels=chans)
     assert np.allclose(data_xr.values, norm_imgs.values * norm_vals)
 
+    # check correct data type
+    assert norm_imgs.dtype == 'float32'
+
     # check that log file has correct values
     log_file = pd.read_csv(os.path.join(norm_dir, 'fov0', 'normalization_coefs.csv'))
     assert np.array_equal(log_file['channels'], chans)

--- a/toffy/normalize_test.py
+++ b/toffy/normalize_test.py
@@ -371,6 +371,7 @@ def test_normalize_fov(tmpdir):
     fovs, chans = test_utils.gen_fov_chan_names(num_fovs=1, num_chans=3)
     _, data_xr = test_utils.create_paired_xarray_fovs(
         tmpdir, fovs, chans, img_shape=(10, 10))
+    data_xr = data_xr.astype('float32')
 
     # create inputs
     norm_vals = np.random.rand(len(chans))
@@ -387,7 +388,7 @@ def test_normalize_fov(tmpdir):
     assert np.allclose(data_xr.values, norm_imgs.values * norm_vals)
 
     # check correct data type
-    assert norm_imgs.dtype == 'float32'
+    assert norm_imgs.dtype == data_xr.dtype
 
     # check that log file has correct values
     log_file = pd.read_csv(os.path.join(norm_dir, 'fov0', 'normalization_coefs.csv'))


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #151. 
When [dividing by the norm values](https://github.com/angelolab/toffy/blob/58f1da1a2530910689f98bf97a3a6e669184f892/toffy/normalize.py#L523)  in `normalize.normalize_fovs()`, the data changed from dytpe float32 to float64.

**How did you implement your changes**

Recasted the normalized image array as type float32 before saving the tiffs. 
Also added a data type check in `normalize_test.py`.