### PR TITLE
Adjust min TMA size to 2x2

### DIFF
--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -664,12 +664,12 @@ def generate_tma_fov_list(tma_corners_path, num_fov_row, num_fov_col):
             "TMA corners file %s does not exist" % tma_corners_path
         )
 
-    # user needs to define at least 3 FOVs along the x- and y-axes
-    if num_fov_row < 3:
-        raise ValueError("Number of TMA-grid rows must be at least 3")
+    # user needs to define at least 2 FOVs along the row- and col-axes
+    if num_fov_row < 2:
+        raise ValueError("Number of TMA-grid rows must be at least 2")
 
-    if num_fov_col < 3:
-        raise ValueError("Number of TMA-grid columns must be at least 3")
+    if num_fov_col < 2:
+        raise ValueError("Number of TMA-grid columns must be at least 2")
 
     # read in tma_corners_path
     tma_corners = json_utils.read_json_file(tma_corners_path, encoding='utf-8')

--- a/toffy/tiling_utils_test.py
+++ b/toffy/tiling_utils_test.py
@@ -500,7 +500,7 @@ def test_validate_tma_corners(top_left, top_right, bottom_left, bottom_right):
 
 @parametrize('extra_coords,extra_names', [param([(1, 2)], ["TheSecondFOV"], marks=value_err),
                                           param([], [])])
-@parametrize('num_row,num_col', [param(2, 3, marks=value_err), param(3, 2, marks=value_err),
+@parametrize('num_row,num_col', [param(1, 3, marks=value_err), param(3, 1, marks=value_err),
                                  param(3, 4)])
 @parametrize('tma_corners_file', [param('bad_path.json', marks=file_missing_err),
                                   param('sample_tma_corners.json')])


### PR DESCRIPTION
**What is the purpose of this PR?**

Previously, the TMA script enforced a strict 3x3 minimum grid size. @HPiyadasa recently had an application that required a 2x11, which made it more difficult for him. Per a discussion with @ngreenwald, we can reduce the min grid size to 2x2.

**How did you implement your changes**

Change the validation check of `num_fov_row` and `num_fov_col` in `generate_tmv_fov_list` to throw a `ValueError if `< 2` instead of `< 3`.

**Remaining issues**

Do we want to support grids that contain a dimension of 1 on either axis?
