### PR TITLE
Fix pulse_height_dir path in normalize notebook

### DIFF
--- a/templates/4b_normalize_image_data.ipynb
+++ b/templates/4b_normalize_image_data.ipynb
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "normalize.normalize_image_data(img_dir=os.path.join(rosetta_base_dir, run_name), norm_dir=normalized_run_dir, pulse_heights_dir=mph_run_dir,\n",
+    "normalize.normalize_image_data(img_dir=os.path.join(rosetta_base_dir, run_name), norm_dir=normalized_run_dir, pulse_height_dir=mph_run_dir,\n",
     "                               panel_info=panel, img_sub_folder=img_sub_folder)"
    ]
   }


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #165. Fixes the `pulse_height_dir` argument in the `4b` notebook.

**How did you implement your changes**

Removes a trailing `s`.
