### PR TITLE
Remove endline in column names from correctly formatted panel

### DIFF
--- a/toffy/panel_utils.py
+++ b/toffy/panel_utils.py
@@ -79,6 +79,7 @@ def convert_panel(panel_path):
     # check for already correctly formatted panel, return as is
     if list(panel.columns) == ['Mass', 'Target', 'Start', 'Stop\n']:
         print(f'{panel_name}.csv has the correct toffy format. Loading in panel data.')
+        panel.columns = ['Mass', 'Target', 'Start', 'Stop']
         return panel
     # if not ionpath panel, raise error
     elif list(panel.columns) != ['ID (Lot)', 'Target', 'Clone', 'Mass', 'Element', 'Manufacture',

--- a/toffy/panel_utils_test.py
+++ b/toffy/panel_utils_test.py
@@ -78,7 +78,7 @@ def test_convert_panel():
         # check that correctly formatted panel loads without issue
         converted_panel.to_csv(os.path.join(temp_dir, 'converted_panel.csv'), index=False)
         result_panel = panel_utils.convert_panel(os.path.join(temp_dir, 'converted_panel.csv'))
-        assert list(result_panel.columns) == ['Mass', 'Target', 'Start', 'Stop\n']
+        assert list(result_panel.columns) == ['Mass', 'Target', 'Start', 'Stop']
 
         # file which is not ionpath or toffy should raise error
         bad_panel = pd.DataFrame({


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

The `convert_panel` function in panel_utils.py reads in files to check if they have a toffy structure. In doing so, the column name 'Stop' becomes 'Stop\n' which interferes with downstream processing such as extracting the bin files. 

**How did you implement your changes**

Change the column names to their correct previous format before returning. Tested within notebook 3a and fixes the issue.
```
panel.columns = ['Mass', 'Target', 'Start', 'Stop']
return panel
```