### PR TITLE
Remove `moly_path` requirement for `remap_to_reorder_fovs`

### DIFF
--- a/templates/2_create_tma_mibi_run.ipynb
+++ b/templates/2_create_tma_mibi_run.ipynb
@@ -262,7 +262,7 @@
    "id": "958dd308-5cdf-4d6f-913f-b40705eb4757",
    "metadata": {},
    "source": [
-    "Set `randomize` to `True` shuffle the order of the FOVs in `remapped_fov_regions`. This avoids potential batch effects of acquisition order."
+    "Set `randomize` to `True` to shuffle the order of the FOVs in `remapped_fov_regions`. This avoids potential batch effects of acquisition order."
    ]
   },
   {

--- a/templates/2_create_tma_mibi_run.ipynb
+++ b/templates/2_create_tma_mibi_run.ipynb
@@ -120,8 +120,7 @@
     "# files the notebook will create\n",
     "auto_fov_names_path = os.path.join(tma_dir, '%s_automatic_fov_names.json' % tma_prefix)\n",
     "mapping_path = os.path.join(tma_dir, '%s_mapping.json' % tma_prefix)\n",
-    "remapped_fov_path = os.path.join(tma_dir, '%s_automatic_run.json' % tma_prefix)\n",
-    "moly_path = os.path.join(tma_dir, '%s_moly_point.json' % tma_prefix)"
+    "remapped_fov_path = os.path.join(tma_dir, '%s_automatic_run.json' % tma_prefix)"
    ]
   },
   {

--- a/templates/2_create_tma_mibi_run.ipynb
+++ b/templates/2_create_tma_mibi_run.ipynb
@@ -263,11 +263,7 @@
    "id": "958dd308-5cdf-4d6f-913f-b40705eb4757",
    "metadata": {},
    "source": [
-    "The variables below will control how the remapped JSON is created\n",
-    "\n",
-    "* `randomize`: shuffle the order of the FOVs in `remapped_fov_regions` to avoid potential batch effects of acquisition order\n",
-    "* `moly_insert`: insert a moly FOV between a specified interval of FOVs\n",
-    "* `moly_interval`: if `moly_insert` is set, controls how many FOVs are between each subsequent moly FOV"
+    "Set `randomize` to `True` shuffle the order of the FOVs in `remapped_fov_regions`. This avoids potential batch effects of acquisition order."
    ]
   },
   {
@@ -277,9 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "randomize = True\n",
-    "moly_insert = True\n",
-    "moly_interval = 5"
+    "randomize = True"
    ]
   },
   {
@@ -296,10 +290,7 @@
     "remapped_fov_regions = tiling_utils.remap_and_reorder_fovs(\n",
     "    manual_fov_regions,\n",
     "    mapping,\n",
-    "    moly_path,\n",
-    "    randomize=randomize,\n",
-    "    moly_insert=moly_insert,\n",
-    "    moly_interval=moly_interval\n",
+    "    randomize=randomize\n",
     ")\n",
     "\n",
     "# save remapped_fov_regions\n",

--- a/toffy/tiling_utils.py
+++ b/toffy/tiling_utils.py
@@ -1770,7 +1770,7 @@ def tma_interactive_remap(manual_fovs, auto_fovs, slide_img, mapping_path,
 
 
 def remap_and_reorder_fovs(manual_fov_regions, manual_to_auto_map,
-                           moly_path, randomize=False,
+                           moly_path=None, randomize=False,
                            moly_insert=False, moly_interval=5):
     """Runs 3 separate tasks on `manual_fov_regions`:
 
@@ -1784,7 +1784,7 @@ def remap_and_reorder_fovs(manual_fov_regions, manual_to_auto_map,
         manual_to_auto_map (dict):
             Defines the mapping of manual to auto FOV names
         moly_path (str):
-            The path to the Moly point to insert
+            The path to the Moly point to insert. Defauls to `None`.
         randomize (bool):
             Whether to randomize the FOVs
         moly_insert (bool):
@@ -1798,16 +1798,18 @@ def remap_and_reorder_fovs(manual_fov_regions, manual_to_auto_map,
             `manual_fov_regions` with new FOV names, randomized, and with Moly points
     """
 
-    # file path validation
-    if not os.path.exists(moly_path):
-        raise FileNotFoundError("Moly point %s does not exist" % moly_path)
+    # only load moly_path and verify moly_interval if moly_insert set
+    if moly_insert:
+        # file path validation
+        if not os.path.exists(moly_path):
+            raise FileNotFoundError("Moly point %s does not exist" % moly_path)
 
-    # load the Moly point in
-    moly_point = json_utils.read_json_file(moly_path, encoding='utf-8')
+        # load the Moly point in
+        moly_point = json_utils.read_json_file(moly_path, encoding='utf-8')
 
-    # error check: moly_interval cannot be less than or equal to 0 if moly_insert is True
-    if moly_insert and (not isinstance(moly_interval, int) or moly_interval < 1):
-        raise ValueError("moly_interval must be a positive integer")
+        # error check: moly_interval must be a positive integer
+        if not isinstance(moly_interval, int) or moly_interval < 1:
+            raise ValueError("moly_interval must be a positive integer")
 
     # define a new fov regions dict for remapped names
     remapped_fov_regions = {}

--- a/toffy/tiling_utils_test.py
+++ b/toffy/tiling_utils_test.py
@@ -1151,9 +1151,7 @@ def test_tma_interactive_remap():
 
 
 @parametrize('randomize_setting', [False, True])
-@parametrize('moly_insert, moly_interval', test_cases._REMAP_MOLY_INTERVAL_CASES)
-@parametrize('moly_path', [param('bad_moly_point.json', marks=file_missing_err),
-                           param('sample_moly_point.json')])
+@parametrize('moly_path,moly_insert,moly_interval', test_cases._REMAP_MOLY_INTERVAL_CASES)
 def test_remap_and_reorder_fovs(moly_path, randomize_setting, moly_insert, moly_interval):
     # define the sample Moly point
     sample_moly_point = test_utils.generate_sample_fov_tiling_entry(

--- a/toffy/tiling_utils_test_cases.py
+++ b/toffy/tiling_utils_test_cases.py
@@ -12,6 +12,7 @@ parametrize = pytest.mark.parametrize
 xfail = pytest.mark.xfail
 
 # shortcuts to make the marks arg in pytest.params easier
+file_missing_err = [xfail(raises=FileNotFoundError, strict=True)]
 value_err = [xfail(raises=ValueError, strict=True)]
 
 
@@ -675,10 +676,12 @@ def generate_sample_annot(check_dist, check_duplicates, check_mismatches):
 
 # testing Moly point insertion for remapping, this one's long so don't put directly in decorator
 _REMAP_MOLY_INTERVAL_CASES = [
-    param(True, 2.5, marks=value_err),
-    param(True, 0, marks=value_err),
-    param(False, 4),
-    param(True, 4),
-    param(False, 2),
-    param(True, 2)
+    param('bad_moly_point.json', True, 4, marks=file_missing_err),
+    param('sample_moly_point.json', True, 2.5, marks=value_err),
+    param('sample_moly_point.json', True, 0, marks=value_err),
+    param('sample_moly_point.json', False, 4),  # standard cases
+    param('sample_moly_point.json', True, 4),
+    param('sample_moly_point.json', False, 2),
+    param('sample_moly_point.json', True, 2),
+    param('bad_moly_point.json', False, 4)
 ]


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #214. The function `remap_to_reorder_fovs` should be run without the need to specify Moly points.

**How did you implement your changes**

Add a check to verify `moly_path` and `moly_interval` only if `moly_insert` is `True`. This will not affect anything downstream because a later check only inserts Moly points if `moly_insert` is `True`.

Default `moly_path` to `None` and remove any mention of `moly_insert` and `moly_interval` in `2_create_tma_mibi_run.ipynb`.
