### PR TITLE
Toffy notebook fixes

### DIFF
--- a/templates/3a_monitor_MIBI_run.ipynb
+++ b/templates/3a_monitor_MIBI_run.ipynb
@@ -133,7 +133,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -147,7 +147,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/templates/4a_compensate_image_data.ipynb
+++ b/templates/4a_compensate_image_data.ipynb
@@ -390,8 +390,8 @@
     "# perform rosetta on the provided runs\n",
     "for run in runs:\n",
     "    print(\"processing run {}\".format(run))\n",
-    "    if not os.path.exists(out_dir):\n",
-    "        os.makedirs(out_dir)\n",
+    "    if not os.path.exists(os.path.join(rosetta_image_dir, run)):\n",
+    "        os.makedirs(os.path.join(rosetta_image_dir, run))\n",
     "    rosetta.compensate_image_data(raw_data_dir=os.path.join(extracted_imgs_dir, run), \n",
     "                                  comp_data_dir=os.path.join(rosetta_image_dir, run), \n",
     "                                  comp_mat_path=final_rosetta_path, panel_info=panel, batch_size=1)"

--- a/toffy/qc_comp.py
+++ b/toffy/qc_comp.py
@@ -310,7 +310,8 @@ def compute_qc_metrics(bin_file_path, extracted_imgs_path, fov_name,
 
     # retrieve the image data from extracted tiff files
     # the image coords should be: ['fov', 'type', 'x', 'y', 'channel']
-    image_data = load_utils.load_imgs_from_tree(extracted_imgs_path, fovs=[fov_name])
+    image_data = load_utils.load_imgs_from_tree(extracted_imgs_path, fovs=[fov_name],
+                                                dtype='float32')
     image_data = format_img_data(image_data)
 
     metric_csvs = compute_qc_metrics_direct(image_data, fov_name, gaussian_blur, blur_factor)

--- a/toffy/qc_comp.py
+++ b/toffy/qc_comp.py
@@ -522,23 +522,8 @@ def visualize_qc_metrics(metric_name, qc_metric_dir, axes_size=16, wrap=6,
     )
 
     # save the figure if specified
-    if save_dir is not None:
-        if ax is None:
-            misc_utils.save_figure(save_dir, '%s_barplot_stats.png' % metric_name, dpi=dpi)
-        else:
-            # TODO: add ax argument to misc_utils.save_figure when moved to tmi
-            if not os.path.exists(save_dir):
-                raise FileNotFoundError("save_dir %s does not exist" % save_dir)
-
-            fig = plt.gcf()
-            extent = ax.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
-
-            # TODO: fine tune extent expansion
-            fig.savefig(
-                os.path.join(save_dir, '%s_barplot_stats.png' % metric_name),
-                dpi=dpi,
-                bbox_inches=extent.expanded(1.1, 1.2)
-            )
+    if save_dir:
+        misc_utils.save_figure(save_dir, '%s_barplot_stats.png' % metric_name, dpi=dpi)
 
 
 def format_img_data(img_data):


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #192. 

**How did you implement your changes**

Minor fixes to `compute_qc_metrics` and the rosetta notebook.
The cropped QC plots issue was fixed by getting rid of the different saving functionality for the watcher and independent notebook via the `ax` arg.

**Remaining issues**

I'm not sure what the intention was behind that arg (seems like it might be solely used for old watcher functionality and might be able to be removed altogether). I can explore it more thoroughly and talk to @ackagel post-workshop. 
