### PR TITLE
Ensure path to `rosetta_matrices` is added in the setup notebook

### DIFF
--- a/templates/1_set_up_toffy.ipynb
+++ b/templates/1_set_up_toffy.ipynb
@@ -65,7 +65,8 @@
     "           'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\tiled_run_jsons', \n",
     "           'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\autolabeled_tma_jsons', \n",
     "           'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\panel_files', 'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\normalization_curve', \n",
-    "           'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\rosetta_testing']\n",
+    "           'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\rosetta_testing',\n",
+    "           'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\rosetta_matrices']\n",
     "\n",
     "for folder in folders:\n",
     "    if not os.path.exists(folder):\n",
@@ -268,7 +269,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -282,7 +283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #234. The compensation notebook needs the `rosetta_matrices` folder on the C drive to be created if it doesn't exist, currently it's not done in `1_set_up_toffy.ipynb`. This should be added in.

**How did you implement your changes**

Add this path to the list of paths that need to be created in the setup notebook.