### PR TITLE
Stitch images function without run file

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,6 @@ The median pulse height (MPH) provides a way to assess the sensitivity of the de
 
 ## Questions?
 
-Feel free to open an [issue](https://github.com/angelolab/toffy/issues) on our GitHub page.
+If you have a general question or are having trouble with part of the repo, head to the [discussions](https://github.com/angelolab/toffy/discussions) tab to get help. If you've found a bug with the codebase, first make sure there's not already an [open issue](https://github.com/angelolab/toffy/issues), and if not, you can then [open an issue](https://github.com/angelolab/toffy/issues/new/choose) describing the bug.
 
 Before opening, please double check and see that someone else hasn't opened an issue for your question already.

--- a/templates/3e_stitch_images.ipynb
+++ b/templates/3e_stitch_images.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# path to directory containing the bin files\n",
+    "# path to directory containing the run file\n",
     "base_dir = os.path.join('D:\\\\Data', run_name) \n",
     "\n",
     "# path to directory containing extracted files\n",

--- a/templates/3e_stitch_images.ipynb
+++ b/templates/3e_stitch_images.ipynb
@@ -69,7 +69,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# path to directory containing the run file\n",
+    "# path to directory containing the run file,\n",
+    "# can be set to None if there's no run file for the images you're stitching\n",
     "base_dir = os.path.join('D:\\\\Data', run_name) \n",
     "\n",
     "# path to directory containing extracted files\n",

--- a/templates/4a_compensate_image_data.ipynb
+++ b/templates/4a_compensate_image_data.ipynb
@@ -134,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# copy random fovs from each run and get image size for tiling\n",
+    "# copy random fovs from each run\n",
     "rosetta.copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs_dir, fovs_per_run=5)\n",
     "\n",
     "# copy rosetta matrix\n",

--- a/templates/4a_compensate_image_data.ipynb
+++ b/templates/4a_compensate_image_data.ipynb
@@ -56,6 +56,7 @@
     "import skimage.io as io\n",
     "from toffy import rosetta\n",
     "from toffy.panel_utils import load_panel\n",
+    "from toffy.image_stitching import get_max_img_size\n",
     "from ark.utils.io_utils import list_folders, list_files"
    ]
   },
@@ -113,7 +114,6 @@
     "\n",
     "rosetta_testing_dir = 'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\rosetta_testing'\n",
     "extracted_imgs_dir = 'D:\\\\Extracted_Images'\n",
-    "base_dir = 'D:\\\\Data'\n",
     "\n",
     "# read in toffy panel file\n",
     "panel = load_panel(panel_path)"
@@ -135,8 +135,7 @@
    "outputs": [],
    "source": [
     "# copy random fovs from each run and get image size for tiling\n",
-    "img_size = rosetta.copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs_dir, base_dir,\n",
-    "                         fovs_per_run=5)\n",
+    "rosetta.copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs_dir, fovs_per_run=5)\n",
     "\n",
     "# copy rosetta matrix\n",
     "shutil.copyfile(default_matrix_path, \n",
@@ -199,7 +198,7 @@
     "    os.makedirs(folder_path)\n",
     "\n",
     "# compensate the example fov images \n",
-    "rosetta.generate_rosetta_test_imgs(rosetta_mat_path, img_out_dir,  multipliers, folder_path, \n",
+    "rosetta.generate_rosetta_test_imgs(rosetta_mat_path, img_out_dir, multipliers, folder_path, \n",
     "                                   panel, current_channel_name, output_channel_names=None)"
    ]
   },
@@ -226,6 +225,7 @@
     "for mult in multipliers:\n",
     "    rosetta_dirs.append(os.path.join(folder_path, f'compensated_data_{mult}'))\n",
     "\n",
+    "img_size = get_max_img_size(img_out_dir)\n",
     "rosetta.create_tiled_comparison(input_dir_list=rosetta_dirs, output_dir=stitched_dir, max_img_size=img_size, \n",
     "                                channels=None)\n",
     "\n",

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -9,11 +9,11 @@ from ark.utils import data_utils, load_utils, io_utils, misc_utils
 from mibi_bin_tools.io_utils import remove_file_extensions
 
 
-def get_max_img_size(run_dir, tiff_out_dir, fov_list=None):
+def get_max_img_size(tiff_out_dir, run_dir=None, fov_list=None):
     """Retrieves the maximum FOV image size listed in the run file, or for the given FOVs
         Args:
-            run_dir (str): path to the run directory containing the run json files
             tiff_out_dir (str): path to the extracted images for the specific run
+            run_dir (str): path to the run directory containing the run json files, default None
             fov_list (list): list of fovs to check max size for, default none which check all fovs
         Returns:
             value of max image size"""
@@ -55,11 +55,11 @@ def get_max_img_size(run_dir, tiff_out_dir, fov_list=None):
     return max_img_size
 
 
-def stitch_images(tiff_out_dir, run_dir, channels=None, img_sub_folder=None):
+def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None):
     """Creates a new directory containing stitched channel images for the run
         Args:
             tiff_out_dir (str): path to the extracted images for the specific run
-            run_dir (str): path to the run directory containing the run json files
+            run_dir (str): path to the run directory containing the run json files, default None
             channels (list): list of channels to produce stitched images for, None will do all
             img_sub_folder (str): optional name of image sub-folder within each fov"""
 
@@ -86,7 +86,7 @@ def stitch_images(tiff_out_dir, run_dir, channels=None, img_sub_folder=None):
 
     # get load and stitching args
     num_cols = math.isqrt(len(folders))
-    max_img_size = get_max_img_size(run_dir, tiff_out_dir)
+    max_img_size = get_max_img_size(tiff_out_dir, run_dir)
 
     # make stitched subdir
     os.makedirs(stitched_dir)

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -18,13 +18,14 @@ def get_max_img_size(tiff_out_dir, run_dir=None, fov_list=None):
         Returns:
             value of max image size"""
 
-    run_name = os.path.basename(run_dir)
-    run_file_path = os.path.join(run_dir, run_name + '.json')
+    if run_dir:
+        run_name = os.path.basename(run_dir)
+        run_file_path = os.path.join(run_dir, run_name + '.json')
 
     img_sizes = []
 
     # check for a run file
-    if os.path.exists(run_file_path):
+    if run_dir and os.path.exists(run_file_path):
         # retrieve all pixel width dimensions of the fovs
         run_data = json_utils.read_json_file(run_file_path)
 

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -18,6 +18,7 @@ def test_get_max_img_size():
         ],
     }
 
+    # test with run file
     with tempfile.TemporaryDirectory() as tmp_dir:
         test_dir = os.path.join(tmp_dir, 'data', 'test_run')
         os.makedirs(test_dir)
@@ -25,11 +26,30 @@ def test_get_max_img_size():
         json_utils.write_json_file(json_path, RUN_JSON_SPOOF)
 
         # test success for all fovs
-        max_img_size = image_stitching.get_max_img_size(test_dir)
+        max_img_size = image_stitching.get_max_img_size(test_dir, 'extracted_dir')
         assert max_img_size == 32
 
         # test success for fov list
-        max_img_size = image_stitching.get_max_img_size(test_dir, ['fov-2-scan-1', 'fov-3-scan-1'])
+        max_img_size = image_stitching.get_max_img_size(test_dir, 'extracted_dir',
+                                                        ['fov-2-scan-1', 'fov-3-scan-1'])
+        assert max_img_size == 16
+
+    # test by reading image sizes
+    with tempfile.TemporaryDirectory() as tmpdir:
+        channel_list = ['Au', 'CD3', 'CD4', 'CD8', 'CD11c']
+        fov_list = ['fov-1-scan-1', 'fov-2-scan-1']
+        larger_fov = ['fov-3-scan-1']
+
+        test_utils._write_tifs(tmpdir, fov_list, channel_list, (16, 16), '', False, int)
+        test_utils._write_tifs(tmpdir, larger_fov, channel_list, (32, 32), '', False, int)
+
+        # test success for all fovs
+        max_img_size = image_stitching.get_max_img_size('bin_dir', tmpdir)
+        assert max_img_size == 32
+
+        # test success for fov list
+        max_img_size = image_stitching.get_max_img_size('bin_dir', tmpdir,
+                                                        ['fov-1-scan-1', 'fov-2-scan-1'])
         assert max_img_size == 16
 
 

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -26,11 +26,11 @@ def test_get_max_img_size():
         json_utils.write_json_file(json_path, RUN_JSON_SPOOF)
 
         # test success for all fovs
-        max_img_size = image_stitching.get_max_img_size(test_dir, 'extracted_dir')
+        max_img_size = image_stitching.get_max_img_size('extracted_dir', test_dir)
         assert max_img_size == 32
 
         # test success for fov list
-        max_img_size = image_stitching.get_max_img_size(test_dir, 'extracted_dir',
+        max_img_size = image_stitching.get_max_img_size('extracted_dir', test_dir,
                                                         ['fov-2-scan-1', 'fov-3-scan-1'])
         assert max_img_size == 16
 
@@ -44,11 +44,11 @@ def test_get_max_img_size():
         test_utils._write_tifs(tmpdir, larger_fov, channel_list, (32, 32), '', False, int)
 
         # test success for all fovs
-        max_img_size = image_stitching.get_max_img_size('bin_dir', tmpdir)
+        max_img_size = image_stitching.get_max_img_size(tmpdir, 'bin_dir')
         assert max_img_size == 32
 
         # test success for fov list
-        max_img_size = image_stitching.get_max_img_size('bin_dir', tmpdir,
+        max_img_size = image_stitching.get_max_img_size(tmpdir, 'bin_dir',
                                                         ['fov-1-scan-1', 'fov-2-scan-1'])
         assert max_img_size == 16
 
@@ -90,5 +90,11 @@ def test_stitch_images(mocker):
 
         # test stitching for images in subdir
         image_stitching.stitch_images(tmpdir, tmpdir, ['Au', 'CD3'], img_sub_folder='sub_dir')
+        assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
+               sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])
+        shutil.rmtree(os.path.join(tmpdir, 'stitched_images'))
+
+        # test stitching for no run_dir
+        image_stitching.stitch_images(tmpdir, channels=['Au', 'CD3'], img_sub_folder='sub_dir')
         assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
                sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -44,7 +44,7 @@ def test_get_max_img_size():
         test_utils._write_tifs(tmpdir, larger_fov, channel_list, (32, 32), '', False, int)
 
         # test success for all fovs
-        max_img_size = image_stitching.get_max_img_size(tmpdir, 'bin_dir')
+        max_img_size = image_stitching.get_max_img_size(tmpdir)
         assert max_img_size == 32
 
         # test success for fov list
@@ -80,7 +80,7 @@ def test_stitch_images(mocker):
         shutil.rmtree(os.path.join(tmpdir, 'stitched_images'))
 
         # test stitching for specific channels
-        image_stitching.stitch_images(tmpdir, tmpdir, ['Au', 'CD3'])
+        image_stitching.stitch_images(tmpdir, channels=['Au', 'CD3'])
         assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
                sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])
         shutil.rmtree(os.path.join(tmpdir, 'stitched_images'))

--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -499,7 +499,7 @@ def create_rosetta_matrices(default_matrix, save_dir, multipliers, masses=None):
         mult_matrix.to_csv(os.path.join(save_dir, base_name + '_mult_%s.csv' % (str(i))))
 
 
-def copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs_dir, bin_file_dir,
+def copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs_dir,
                      fovs_per_run=5):
     """ Creates a new directory for rosetta testing and copies over a random subset of
         previously extracted images
@@ -508,14 +508,11 @@ def copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs
         run_names (list): gives names of run folders to retrieve extracted images from
         rosetta_testing_dir (str): directory where to create cohort rosetta testing folder
         extracted_imgs_dir (str): directory containing images from each run,
-        bin_file_dir (str): directory containing json run file
         fovs_per_run: number of fovs from each run to use for testing, default 5
-    Returns:
-        max_img_size (int) which is the largest fov image size of the testing fovs chosen
 
     """
     # path validation
-    validate_paths([rosetta_testing_dir, extracted_imgs_dir, bin_file_dir], data_prefix=False)
+    validate_paths([rosetta_testing_dir, extracted_imgs_dir], data_prefix=False)
 
     # validate provided run names
     for run in run_names:
@@ -527,7 +524,6 @@ def copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs
     os.makedirs(os.path.join(cohort_rosetta_dir, 'extracted_images'))
 
     # randomly choose fovs from a run and copy them to the img subdir in rosetta testing dir
-    max_img_size = 0
     for i, run in enumerate(ns.natsorted(run_names)):
         run_path = os.path.join(extracted_imgs_dir, run)
 
@@ -535,19 +531,12 @@ def copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs
         fovs_in_run = ns.natsorted(fovs_in_run)
         rosetta_fovs = random.sample(fovs_in_run, k=fovs_per_run)
 
-        # check for largest image size in run
-        img_size = image_stitching.get_max_img_size(os.path.join(bin_file_dir, run), rosetta_fovs)
-        if img_size > max_img_size:
-            max_img_size = img_size
-
         for fov in rosetta_fovs:
             fov_path = os.path.join(os.path.join(extracted_imgs_dir, run, fov))
             # prepend the run name to each fov
             new_path = os.path.join(os.path.join(cohort_rosetta_dir, 'extracted_images',
                                                  run + '_' + fov))
             shutil.copytree(fov_path, new_path)
-
-    return max_img_size
 
 
 def rescale_raw_imgs(img_out_dir, scale=200):

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -448,47 +448,40 @@ def test_copy_image_files(mocker):
     mocker.patch('toffy.image_stitching.get_max_img_size', mock_img_size)
 
     run_names = ['run_1', 'run_2', 'run_3']
-    with tempfile.TemporaryDirectory() as bin_dir:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            for i in range(0, 3):
-                run_folder = os.path.join(temp_dir, run_names[i])
-                bin_folder = os.path.join(bin_dir, run_names[i])
-                os.makedirs(run_folder)
-                for j in range(1, 6):
-                    os.makedirs(os.path.join(run_folder, f'fov-{j}'))
-                    test_utils._make_blank_file(os.path.join(
-                        run_folder, f'fov-{j}'), 'test_image.tif')
-                os.makedirs(os.path.join(run_folder, 'stitched_images'))
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for i in range(0, 3):
+            run_folder = os.path.join(temp_dir, run_names[i])
+            os.makedirs(run_folder)
+            for j in range(1, 6):
+                os.makedirs(os.path.join(run_folder, f'fov-{j}'))
+                test_utils._make_blank_file(os.path.join(
+                    run_folder, f'fov-{j}'), 'test_image.tif')
+            os.makedirs(os.path.join(run_folder, 'stitched_images'))
 
-            with tempfile.TemporaryDirectory() as temp_dir2:
-                # bad run name should raise an error
-                with pytest.raises(ValueError, match='not a valid run name'):
-                    rosetta.copy_image_files('cohort_name', ['bad_name'], temp_dir2, temp_dir,
-                                             bin_dir)
+        with tempfile.TemporaryDirectory() as temp_dir2:
+            # bad run name should raise an error
+            with pytest.raises(ValueError, match='not a valid run name'):
+                rosetta.copy_image_files('cohort_name', ['bad_name'], temp_dir2, temp_dir)
 
-                # bad paths should raise an error
-                with pytest.raises(ValueError, match='could not be found'):
-                    rosetta.copy_image_files('cohort_name', run_names, 'bad_path', temp_dir,
-                                             bin_dir)
-                    rosetta.copy_image_files('cohort_name', run_names, temp_dir2, 'bad_path',
-                                             bin_dir)
+            # bad paths should raise an error
+            with pytest.raises(ValueError, match='could not be found'):
+                rosetta.copy_image_files('cohort_name', run_names, 'bad_path', temp_dir)
+                rosetta.copy_image_files('cohort_name', run_names, temp_dir2, 'bad_path')
 
-                # test successful folder copy
-                img_size = rosetta.copy_image_files('cohort_name', run_names, temp_dir2, temp_dir,
-                                                    bin_dir, fovs_per_run=5)
-                assert img_size == 32
+            # test successful folder copy
+            rosetta.copy_image_files('cohort_name', run_names, temp_dir2, temp_dir, fovs_per_run=5)
 
-                # check that correct total and per run fovs are copied
-                extracted_fov_dir = os.path.join(temp_dir2, 'cohort_name', 'extracted_images')
-                assert len(list_folders(extracted_fov_dir)) == 15
-                for i in range(1, 4):
-                    assert len(list(list_folders(extracted_fov_dir, f'run_{i}'))) == 5
-                assert len(list(list_folders(extracted_fov_dir, 'stitched_images'))) == 0
+            # check that correct total and per run fovs are copied
+            extracted_fov_dir = os.path.join(temp_dir2, 'cohort_name', 'extracted_images')
+            assert len(list_folders(extracted_fov_dir)) == 15
+            for i in range(1, 4):
+                assert len(list(list_folders(extracted_fov_dir, f'run_{i}'))) == 5
+            assert len(list(list_folders(extracted_fov_dir, 'stitched_images'))) == 0
 
-                # check that files in fov folders are copied
-                for folder in list_folders(extracted_fov_dir):
-                    assert os.path.exists(os.path.join(
-                        extracted_fov_dir, folder, 'test_image.tif'))
+            # check that files in fov folders are copied
+            for folder in list_folders(extracted_fov_dir):
+                assert os.path.exists(os.path.join(
+                    extracted_fov_dir, folder, 'test_image.tif'))
 
 
 def test_rescale_raw_imgs():


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Closes #228.
To allow stitch_images() to work without needing a run file. 

**How did you implement your changes**

Made the `run_dir` an optional arg in both functions. The get_max_img_size function was altered to check for a run file when a run_dir is provided. If not, it reads in a test file from each FOV folder in the extracted images directory and uses those image sizes to find the maximum.

**Remaining issues**

- [x] edit the notebook documentation to make clear you can have base_dir=None
- [x]  implement for rosetta notebook so there's no need for base_dir