### PR TITLE
Ignore stitched_images folder in rosetta processing

### DIFF
--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -213,7 +213,7 @@ def compensate_image_data(raw_data_dir, comp_data_dir, comp_mat_path, panel_info
                    data_prefix=False)
 
     # get list of all fovs
-    fovs = list_folders(raw_data_dir)
+    fovs = list_folders(raw_data_dir, substrs='fov')
 
     # load csv files
     comp_mat = pd.read_csv(comp_mat_path, index_col=0)

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -204,6 +204,7 @@ def test_compensate_image_data(output_masses, input_masses, gaus_rad, save_forma
         fovs, chans = test_utils.gen_fov_chan_names(num_fovs=3, num_chans=3)
         filelocs, data_xr = test_utils.create_paired_xarray_fovs(
             data_dir, fovs, chans, img_shape=(10, 10), fills=True)
+        os.makedirs(os.path.join(data_dir, 'stitched_images'))
 
         # create compensation matrix
         comp_mat_path = os.path.join(data_dir, 'comp_mat.csv')


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #238.
To ignore the stitched_images folder when compensating all FOVs in a run.

**How did you implement your changes**

Only include folders in the list which have a 'fov' substring.
