### PR TITLE
Rosetta mass 39 naming conflict

### DIFF
--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -182,7 +182,7 @@ def get_masses_from_channel_names(names, panel_df):
 def compensate_image_data(raw_data_dir, comp_data_dir, comp_mat_path, panel_info,
                           input_masses=None, output_masses=None, save_format='rescaled',
                           raw_data_sub_folder='', batch_size=1, gaus_rad=1, norm_const=200,
-                          ffc_channels=['chan_39'], correct_streaks=False, streak_chan='Noodle'):
+                          ffc_masses=[39], correct_streaks=False, streak_chan='Noodle'):
     """Function to compensate MIBI data with a flow-cytometry style compensation matrix
 
     Args:
@@ -204,7 +204,7 @@ def compensate_image_data(raw_data_dir, comp_data_dir, comp_mat_path, panel_info
         batch_size: number of images to process at a time
         gaus_rad: radius for blurring image data. Passing 0 will result in no blurring
         norm_const: constant used for rescaling if save_format == 'rescaled'
-        ffc_channels (list): channels that need to be flat field corrected.
+        ffc_masses (list): masses that need to be flat field corrected.
         correct_streaks (bool): whether to correct streaks in the image
         streak_chan (str): the channel to use for streak correction
     """
@@ -220,6 +220,10 @@ def compensate_image_data(raw_data_dir, comp_data_dir, comp_mat_path, panel_info
     acquired_masses = panel_info['Mass'].values
     acquired_targets = panel_info['Target'].values
     all_masses = comp_mat.columns.values.astype('int')
+
+    # convert ffc mass into ffc channel names
+    ffc_channels = [panel_info.loc[panel_info.Mass == mass].Target.values[0] for
+                    mass in ffc_masses]
 
     validate_inputs(raw_data_dir, comp_mat, acquired_masses, acquired_targets, input_masses,
                     output_masses, all_masses, fovs, save_format, raw_data_sub_folder, batch_size,

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -214,7 +214,7 @@ def test_compensate_image_data(output_masses, input_masses, gaus_rad, save_forma
         rosetta.compensate_image_data(data_dir, output_dir, comp_mat_path, panel_info,
                                       input_masses=input_masses, output_masses=output_masses,
                                       save_format=save_format, gaus_rad=gaus_rad,
-                                      ffc_channels=['chan1'], correct_streaks=True,
+                                      ffc_masses=[50], correct_streaks=True,
                                       streak_chan='chan1')
 
         # all folders created


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #251.

**How did you implement your changes**

Take input `ffc_masses` as an argument and retrieve the specific channel name from the provided `panel_info`.

**Remaining issues**

There's a few functions that similarly have [Noodle](https://github.com/angelolab/toffy/blob/f8f2986d4d943cb023cdc298c50b86d30932ffe1/toffy/rosetta.py#L185) provided as a specified channel name. Is there any instance where there would be a conflict for mass 117, or can we just leave the provided Noodle identifier as is?
