### PR TITLE
Custom error for Rosetta file copying

### DIFF
--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -519,9 +519,17 @@ def copy_image_files(cohort_name, run_names, rosetta_testing_dir, extracted_imgs
     validate_paths([rosetta_testing_dir, extracted_imgs_dir], data_prefix=False)
 
     # validate provided run names
+    small_runs = []
     for run in run_names:
         if not os.path.exists(os.path.join(extracted_imgs_dir, run)):
             raise ValueError(f'{run} is not a valid run name found in {extracted_imgs_dir}')
+        fovs_in_run = list_folders(os.path.join(extracted_imgs_dir, run), substrs='fov')
+        # check number of fovs in each run
+        if len(fovs_in_run) < fovs_per_run:
+            small_runs.append(run)
+    if len(small_runs) > 0:
+        raise ValueError(f"The run folders {small_runs} do not contain the minimum amount of FOVs "
+                         f"({fovs_per_run}) defined by the fovs_per_run given.")
 
     # make rosetta testing dir and extracted images subdir
     cohort_rosetta_dir = os.path.join(rosetta_testing_dir, cohort_name)

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -469,6 +469,11 @@ def test_copy_image_files(mocker):
                 rosetta.copy_image_files('cohort_name', run_names, 'bad_path', temp_dir)
                 rosetta.copy_image_files('cohort_name', run_names, temp_dir2, 'bad_path')
 
+            # not enough fov files for provided arg
+            with pytest.raises(ValueError, match='do not contain the minimum amount of FOVs'):
+                rosetta.copy_image_files('cohort_name', run_names, temp_dir2, temp_dir,
+                                         fovs_per_run=10)
+
             # test successful folder copy
             rosetta.copy_image_files('cohort_name', run_names, temp_dir2, temp_dir, fovs_per_run=5)
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #257.

**How did you implement your changes**

Before copying any files, the `copy_image_files` function now checks that each of the provided runs contains at least the same number of subfolders as the `fovs_per_run` provided by the user. If not, it gives an error message detailing the names of the small runs and the number of minimum fovs needed.
