### PR TITLE
Add _pulse_height.csv file generation to watcher

### DIFF
--- a/templates/3a_monitor_MIBI_run.ipynb
+++ b/templates/3a_monitor_MIBI_run.ipynb
@@ -111,10 +111,11 @@
    "source": [
     "fov_callback, run_callback = build_callbacks(\n",
     "    run_callbacks = ['plot_qc_metrics', 'plot_mph_metrics', 'image_stitching'],\n",
-    "    fov_callbacks = ['extract_tiffs'],\n",
+    "    fov_callbacks = ['extract_tiffs', 'generate_pulse_heights'],\n",
     "    tiff_out_dir=extraction_dir,\n",
     "    qc_out_dir=metrics_data_dir,\n",
     "    mph_out_dir=metrics_data_dir,\n",
+    "    pulse_out_dir=metrics_data_dir,\n",
     "    plot_dir=metrics_plot_dir,\n",
     "    save_dir=metrics_plot_dir,\n",
     "    panel=panel,\n",

--- a/templates/3a_monitor_MIBI_run.ipynb
+++ b/templates/3a_monitor_MIBI_run.ipynb
@@ -7,7 +7,7 @@
     "# Monitoring an ongoing MIBI run\n",
     "\n",
     "This notebook can be run alongside an active MIBIScope run.  As images are generated, this notebook will automatically pass the data through pre-specified functions, like tiff \n",
-    "extraction, qc metric computation, etc. Eventually, all of the processing steps in the toffy repo will be incorporated into the Watcher functionality here. For now, this notebook will automatically extract tiffs, stitch images by channel, and generate the QC and MPH plots of your data. "
+    "extraction, qc metric computation, etc. Eventually, all of the processing steps in the toffy repo will be incorporated into the Watcher functionality here. For now, this notebook will automatically extract tiffs, compute pulse height data, stitch images by channel, and generate the QC and MPH plots of your data. "
    ]
   },
   {
@@ -92,7 +92,10 @@
     "\n",
     "Callbacks listed in `fov_callbacks` arugment will be run on each completed FOV, the moment both the .bin & .json are found.\n",
     "\n",
-    "* The `extract_tiffs` fov callback specifies that every FOV generate tiffs according to the supplied `panel`. <br/> (See [3b_extract_images_from_bin](./3b_extract_images_from_bin.ipynb) for more details.)\n",
+    "* The `extract_tiffs` callback specifies that every FOV generates tiffs according to the supplied `panel`. <br/> (See [3b_extract_images_from_bin](./3b_extract_images_from_bin.ipynb) for more details.)\n",
+    "\n",
+    "* The `generate_pulse_heights` FOV callback computes the median pulse heights for each mass specified in the `panel`. \n",
+    "<br/> (See [4b_normalize_image_data](./4b_normalize_image_data.ipynb) for more details.)\n",
     "\n",
     "Callbacks listed in the `run_callbacks` argument will be run only once all expected FOV's have been discovered and processed. \n",
     "\n",

--- a/templates/4b_normalize_image_data.ipynb
+++ b/templates/4b_normalize_image_data.ipynb
@@ -78,7 +78,7 @@
     "bin_base_dir = 'D:\\\\Data'\n",
     "rosetta_base_dir = 'D:\\\\Rosetta_Compensated_Images'\n",
     "normalized_base_dir = 'D:\\\\Normalized_Images'\n",
-    "mph_base_dir = 'D:\\\\Data'\n",
+    "mph_run_dir = os.path.join('C:\\\\Users\\\\Customer.ION\\\\Documents\\\\run_metrics', run_name, 'fov_data')\n",
     "\n",
     "# check the run for changes in detector voltage\n",
     "normalize.check_detector_voltage(os.path.join(bin_base_dir, run_name))"
@@ -108,7 +108,6 @@
     "    os.makedirs(normalized_run_dir)\n",
     "    \n",
     "# create directory to hold associated processing files\n",
-    "mph_run_dir = os.path.join(mph_base_dir, run_name)\n",
     "if not os.path.exists(mph_run_dir):\n",
     "    os.makedirs(mph_run_dir)"
    ]
@@ -162,7 +161,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -176,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/templates/4b_normalize_image_data.ipynb
+++ b/templates/4b_normalize_image_data.ipynb
@@ -128,7 +128,7 @@
    "outputs": [],
    "source": [
     "# get all FOVs\n",
-    "fovs = list_folders(os.path.join(rosetta_base_dir, run_name))\n",
+    "fovs = list_folders(os.path.join(rosetta_base_dir, run_name), substrs='fov-')\n",
     "\n",
     "# loop over each FOV\n",
     "for fov in fovs:\n",

--- a/toffy/fov_watcher_test.py
+++ b/toffy/fov_watcher_test.py
@@ -89,12 +89,14 @@ def test_watcher(mock_viz_qc, mock_viz_mph, run_cbs, fov_cbs, kwargs, validators
             qc_out_dir = os.path.join(tmpdir, 'cb_1', RUN_DIR_NAME)
             mph_out_dir = os.path.join(tmpdir, 'cb_2', RUN_DIR_NAME)
             plot_dir = os.path.join(tmpdir, 'cb_2_plots', RUN_DIR_NAME)
+            pulse_out_dir = os.path.join(tmpdir, 'cb_3', RUN_DIR_NAME)
             stitched_dir = os.path.join(tmpdir, 'cb_0', RUN_DIR_NAME, 'stitched_images')
 
             # add directories to kwargs
             kwargs['tiff_out_dir'] = tiff_out_dir
             kwargs['qc_out_dir'] = qc_out_dir
             kwargs['mph_out_dir'] = mph_out_dir
+            kwargs['pulse_out_dir'] = pulse_out_dir
             kwargs['plot_dir'] = plot_dir
 
             run_data = os.path.join(tmpdir, 'test_run')
@@ -154,6 +156,9 @@ def test_watcher(mock_viz_qc, mock_viz_mph, run_cbs, fov_cbs, kwargs, validators
 
             # stitch images check
             validators[3](os.path.join(tmpdir, 'cb_0', RUN_DIR_NAME, 'stitched_images'))
+
+            # pulse heights check
+            validators[4](os.path.join(tmpdir, 'cb_3', RUN_DIR_NAME), fovs, bad_fovs)
 
     except OSError:
         warnings.warn('Temporary file cleanup was incomplete.')

--- a/toffy/normalize.py
+++ b/toffy/normalize.py
@@ -54,7 +54,7 @@ def write_counts_per_mass(base_dir, output_dir, fov, masses, start_offset=0.5,
 
 
 def write_mph_per_mass(base_dir, output_dir, fov, masses, start_offset=0.5, stop_offset=0.5):
-    """Records the mean pulse height (MPH) per mass for the specified FOV
+    """Records the median pulse height (MPH) per mass for the specified FOV
 
     Args:
         base_dir (str): the directory containing the FOV

--- a/toffy/test_utils.py
+++ b/toffy/test_utils.py
@@ -276,8 +276,8 @@ def check_pulse_dir_structure(pulse_out_dir: str, point_names: List[str], bad_po
     """
 
     for point, bad in zip(point_names, bad_points):
-        assert os.path.exists(os.path.join(pulse_out_dir, f'{point}-pulse_heights.csv'))
-        assert not os.path.exists(os.path.join(pulse_out_dir, f'{bad}-pulse_heights.csv'))
+        assert os.path.exists(os.path.join(pulse_out_dir, f'{point}_pulse_heights.csv'))
+        assert not os.path.exists(os.path.join(pulse_out_dir, f'{bad}_pulse_heights.csv'))
 
 
 def check_stitched_dir_structure(stitched_dir: str, channels: List[str]):

--- a/toffy/test_utils.py
+++ b/toffy/test_utils.py
@@ -107,7 +107,7 @@ def mock_visualize_mph(mph_df, out_dir, regression: bool = False):
         _make_small_file(out_dir, 'fov_vs_mph.jpg')
 
 
-class ExtractionQCGenerationCases:
+class FovCallbackCases:
     def case_all_callbacks(self):
         panel_path = os.path.join(Path(__file__).parent, 'data', 'sample_panel.csv')
         return FOV_CALLBACKS, {'panel': pd.read_csv(panel_path)}
@@ -150,7 +150,7 @@ class ExtractionQCGenerationCases:
         return ['invalid_callback'], {}
 
 
-class PlotQCMetricsCases:
+class RunCallbackCases:
     def case_default(self):
         panel_path = os.path.join(Path(__file__).parent, 'data', 'sample_panel.csv')
         return RUN_CALLBACKS, {'panel': pd.read_csv(panel_path)}
@@ -343,9 +343,9 @@ def create_sample_run(name_list, run_order_list, scan_count_list, create_json=Fa
     return sample_run
 
 
-# calling cases for the built extraction/qc callback
+# calling cases for data to test against
 # this should be limited to folders to call; no generation parameters allowed  >:(
-class ExtractionQCCallCases:
+class WatcherTestData:
     def case_combined(self):
         return os.path.join(Path(__file__).parent, 'data', 'combined')
 

--- a/toffy/watcher_callbacks.py
+++ b/toffy/watcher_callbacks.py
@@ -242,11 +242,6 @@ class FovCallbacks:
         if not os.path.exists(pulse_out_dir):
             os.makedirs(pulse_out_dir)
 
-        if self.__fov_data is None:
-            if panel is None:
-                raise ValueError('Must provide panel if fov data is not already generated...')
-            self._generate_fov_data(panel, **kwargs)
-
         write_mph_per_mass(
             base_dir=self.run_folder,
             output_dir=pulse_out_dir,

--- a/toffy/watcher_callbacks.py
+++ b/toffy/watcher_callbacks.py
@@ -230,7 +230,7 @@ class FovCallbacks:
         """Generates pulse height csvs from bin files, and saves output to provided directory
 
         Args:
-            pulse_out_dir (str): where to output pulse height csvs to
+            pulse_out_dir (str): where to output pulse height csvs
             panel (pd.DataFrame): Target mass integration ranges
             **kwargs (dict):
                 Additional arguments for `toffy.normalize.write_mph_per_mass`. Accepted kwargs are:

--- a/toffy/watcher_callbacks.py
+++ b/toffy/watcher_callbacks.py
@@ -13,11 +13,9 @@ from mibi_bin_tools.bin_files import extract_bin_files, _write_out
 from mibi_bin_tools.type_utils import any_true
 
 from toffy.qc_comp import compute_qc_metrics_direct, combine_qc_metrics, visualize_qc_metrics
-
 from toffy.mph_comp import compute_mph_metrics, combine_mph_metrics, visualize_mph
-
 from toffy.image_stitching import stitch_images
-
+from toffy.normalize import write_mph_per_mass
 from toffy.settings import QC_COLUMNS, QC_SUFFIXES
 
 
@@ -144,7 +142,7 @@ class FovCallbacks:
             tiff_out_dir (str):
                 Path where tiffs are written
             panel (pd.DataFrame):
-                Target massf integration ranges
+                Target mass integration ranges
             **kwargs (dict):
                 Additional arguments for `mibi_bin_tools.bin_files.extract_bin_files`.
                 Accepted kwargs are
@@ -208,14 +206,12 @@ class FovCallbacks:
 
         Args:
             mph_out_dir (str): where to output mph csvs to
-
             **kwargs (dict):
                 Additional arguments for `toffy.qc_comp.compute_mph_metrics`. Accepted kwargs are:
 
              - mass
              - mass_start
              - mass_stop
-
         """
 
         if not os.path.exists(mph_out_dir):
@@ -229,6 +225,35 @@ class FovCallbacks:
             mass_start=kwargs.get('mass_start', 97.5),
             mass_stop=kwargs.get('mass_stop', 98.5),
         )
+
+    def generate_pulse_heights(self, pulse_out_dir: str, panel: pd.DataFrame = None, **kwargs):
+        """Generates pulse height csvs from bin files, and saves output to provided directory
+
+        Args:
+            pulse_out_dir (str): where to output pulse height csvs to
+            panel (pd.DataFrame): Target mass integration ranges
+            **kwargs (dict):
+                Additional arguments for `toffy.normalize.write_mph_per_mass`. Accepted kwargs are:
+
+             - start_offset
+             - stop_offset
+        """
+
+        if not os.path.exists(pulse_out_dir):
+            os.makedirs(pulse_out_dir)
+
+        if self.__fov_data is None:
+            if panel is None:
+                raise ValueError('Must provide panel if fov data is not already generated...')
+            self._generate_fov_data(panel, **kwargs)
+
+        write_mph_per_mass(
+            base_dir=self.run_folder,
+            output_dir=pulse_out_dir,
+            fov=self.point_name,
+            masses=panel['Mass'].values,
+            start_offset=kwargs.get('mass_start', 0.3),
+            stop_offset=kwargs.get('mass_stop', 0))
 
 
 def build_fov_callback(*args, **kwargs):

--- a/toffy/watcher_callbacks_test.py
+++ b/toffy/watcher_callbacks_test.py
@@ -16,6 +16,7 @@ from toffy.test_utils import (
     check_extraction_dir_structure,
     check_qc_dir_structure,
     check_mph_dir_structure,
+    check_pulse_dir_structure,
     check_stitched_dir_structure,
 )
 
@@ -37,11 +38,12 @@ def test_build_fov_callback(callbacks, kwargs, data_path):
     with tempfile.TemporaryDirectory() as tmp_dir:
 
         extracted_dir = os.path.join(tmp_dir, 'extracted')
-        qc_dir = os.path.join(tmp_dir, 'qc')
+        file_dir = os.path.join(tmp_dir, 'fov_data')
         plot_dir = os.path.join(tmp_dir, 'plots')
         kwargs['tiff_out_dir'] = extracted_dir
-        kwargs['qc_out_dir'] = qc_dir
-        kwargs['mph_out_dir'] = qc_dir
+        kwargs['qc_out_dir'] = file_dir
+        kwargs['mph_out_dir'] = file_dir
+        kwargs['pulse_out_dir'] = file_dir
         kwargs['plot_dir'] = plot_dir
 
         run_data = os.path.join(tmp_dir, 'tissue')
@@ -68,9 +70,11 @@ def test_build_fov_callback(callbacks, kwargs, data_path):
             check_extraction_dir_structure(extracted_dir, point_names, [], ['SMA'],
                                            intensities, replace)
         if 'generate_qc' in callbacks:
-            check_qc_dir_structure(qc_dir, point_names, [])
+            check_qc_dir_structure(file_dir, point_names, [])
         if 'generate_mph' in callbacks:
-            check_mph_dir_structure(qc_dir, plot_dir, point_names, [])
+            check_mph_dir_structure(file_dir, plot_dir, point_names, [])
+        if 'generate_pulse_heights' in callbacks:
+            check_pulse_dir_structure(file_dir, point_names, [])
 
 
 @patch('toffy.watcher_callbacks.visualize_qc_metrics', side_effect=mock_visualize_qc_metrics)

--- a/toffy/watcher_callbacks_test.py
+++ b/toffy/watcher_callbacks_test.py
@@ -10,9 +10,9 @@ from toffy import watcher_callbacks
 from toffy.json_utils import write_json_file
 from toffy.test_utils import (
     mock_visualize_qc_metrics,
-    ExtractionQCGenerationCases,
-    ExtractionQCCallCases,
-    PlotQCMetricsCases,
+    FovCallbackCases,
+    WatcherTestData,
+    RunCallbackCases,
     check_extraction_dir_structure,
     check_qc_dir_structure,
     check_mph_dir_structure,
@@ -28,8 +28,8 @@ COMBINED_RUN_JSON_SPOOF = {
 }
 
 
-@parametrize_with_cases('callbacks, kwargs', cases=ExtractionQCGenerationCases)
-@parametrize_with_cases('data_path',  cases=ExtractionQCCallCases)
+@parametrize_with_cases('callbacks, kwargs', cases=FovCallbackCases)
+@parametrize_with_cases('data_path',  cases=WatcherTestData)
 def test_build_fov_callback(callbacks, kwargs, data_path):
 
     intensities = kwargs.get('intensities', ['Au', 'chan_39'])
@@ -78,8 +78,8 @@ def test_build_fov_callback(callbacks, kwargs, data_path):
 
 
 @patch('toffy.watcher_callbacks.visualize_qc_metrics', side_effect=mock_visualize_qc_metrics)
-@parametrize_with_cases('callbacks, kwargs', cases=PlotQCMetricsCases)
-@parametrize_with_cases('data_path', cases=ExtractionQCCallCases)
+@parametrize_with_cases('callbacks, kwargs', cases=RunCallbackCases)
+@parametrize_with_cases('data_path', cases=WatcherTestData)
 def test_build_callbacks(viz_mock, callbacks, kwargs, data_path):
     with tempfile.TemporaryDirectory() as tmp_dir:
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #261. Adds pulse height file generation to the real-time monitoring notebook, to shorten the length of time it takes to run the 4b notebook.

**How did you implement your changes**

Create the FOV level callback `generate_pulse_heights` and implement in notebook 3a. Also add corresponding test cases and validation functions. 

**Remaining issues**

- [x] clean up the test cases and variable names in `fov_watcher_test.py`
- [x] notebook uses mass args `start_offset=0.3` ` stop_offset=0`, but the function `write_mph_per_mass` itself has 0.5 set as defaults for both?
