### PR TITLE
get_max_img_size works with subdir

### DIFF
--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -9,10 +9,11 @@ from ark.utils import data_utils, load_utils, io_utils, misc_utils
 from mibi_bin_tools.io_utils import remove_file_extensions
 
 
-def get_max_img_size(tiff_out_dir, run_dir=None, fov_list=None):
+def get_max_img_size(tiff_out_dir, img_sub_folder='', run_dir=None, fov_list=None):
     """Retrieves the maximum FOV image size listed in the run file, or for the given FOVs
         Args:
             tiff_out_dir (str): path to the extracted images for the specific run
+            img_sub_folder (str): optional name of image sub-folder within each fov
             run_dir (str): path to the run directory containing the run json files, default None
             fov_list (list): list of fovs to check max size for, default none which check all fovs
         Returns:
@@ -45,10 +46,10 @@ def get_max_img_size(tiff_out_dir, run_dir=None, fov_list=None):
     else:
         if not fov_list:
             fov_list = io_utils.list_folders(tiff_out_dir, substrs='fov-')
-        channels = io_utils.list_files(os.path.join(tiff_out_dir, fov_list[0]))
+        channels = io_utils.list_files(os.path.join(tiff_out_dir, fov_list[0], img_sub_folder))
         # check image size for each fov
         for fov in fov_list:
-            test_file = io.imread(os.path.join(tiff_out_dir, fov, channels[0]))
+            test_file = io.imread(os.path.join(tiff_out_dir, fov, img_sub_folder, channels[0]))
             img_sizes.append(test_file.shape[1])
 
     # largest in run
@@ -87,7 +88,7 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
 
     # get load and stitching args
     num_cols = math.isqrt(len(folders))
-    max_img_size = get_max_img_size(tiff_out_dir, run_dir)
+    max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)
 
     # make stitched subdir
     os.makedirs(stitched_dir)

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -26,12 +26,12 @@ def test_get_max_img_size():
         json_utils.write_json_file(json_path, RUN_JSON_SPOOF)
 
         # test success for all fovs
-        max_img_size = image_stitching.get_max_img_size('extracted_dir', test_dir)
+        max_img_size = image_stitching.get_max_img_size('extracted_dir', run_dir=test_dir)
         assert max_img_size == 32
 
         # test success for fov list
-        max_img_size = image_stitching.get_max_img_size('extracted_dir', test_dir,
-                                                        ['fov-2-scan-1', 'fov-3-scan-1'])
+        max_img_size = image_stitching.get_max_img_size('extracted_dir', run_dir=test_dir,
+                                                        fov_list=['fov-2-scan-1', 'fov-3-scan-1'])
         assert max_img_size == 16
 
     # test by reading image sizes
@@ -48,9 +48,22 @@ def test_get_max_img_size():
         assert max_img_size == 32
 
         # test success for fov list
-        max_img_size = image_stitching.get_max_img_size(tmpdir, 'bin_dir',
-                                                        ['fov-1-scan-1', 'fov-2-scan-1'])
+        max_img_size = image_stitching.get_max_img_size(tmpdir, run_dir='bin_dir',
+                                                        fov_list=['fov-1-scan-1', 'fov-2-scan-1'])
         assert max_img_size == 16
+
+    # test by reading image sizes in subdir
+    with tempfile.TemporaryDirectory() as tmpdir:
+        channel_list = ['Au', 'CD3', 'CD4', 'CD8', 'CD11c']
+        fov_list = ['fov-1-scan-1', 'fov-2-scan-1']
+        larger_fov = ['fov-3-scan-1']
+
+        test_utils._write_tifs(tmpdir, fov_list, channel_list, (16, 16), 'sub_dir', False, int)
+        test_utils._write_tifs(tmpdir, larger_fov, channel_list, (32, 32), 'sub_dir', False, int)
+
+        # test success for all fovs
+        max_img_size = image_stitching.get_max_img_size(tmpdir, img_sub_folder='sub_dir')
+        assert max_img_size == 32
 
 
 def test_stitch_images(mocker):


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #263. Make image size reading in `get_max_img_size` compatible with subdirectory structure. 

**How did you implement your changes**
Pass `sub_dir` as optional argument in the function. 

**Remaining Issues**

- [x] test notebook with subdir and no run file