### PR TITLE
Fix extraction logic for run with a single fov crash

### DIFF
--- a/toffy/bin_extraction.py
+++ b/toffy/bin_extraction.py
@@ -28,6 +28,10 @@ def extract_missing_fovs(bin_file_dir, extraction_dir, panel,
     if empty_fovs:
         fovs = list(set(fovs).difference(empty_fovs))
 
+    if len(fovs) == 0:
+        warnings.warn(f"No viable bin files were found in {bin_file_dir}", Warning)
+        return
+
     # check for moly fovs
     moly_fovs = list_moly_fovs(bin_file_dir, fovs)
 

--- a/toffy/json_utils.py
+++ b/toffy/json_utils.py
@@ -70,12 +70,17 @@ def list_moly_fovs(bin_file_dir, fov_list=None):
     Returns:
         list: list of FOVs which are moly FOVs"""
 
+    run_name = os.path.basename(bin_file_dir)
+
     # check provided fovs
     if fov_list:
         json_files = [fov + '.json' for fov in fov_list]
     # check all fovs in bin_file_dir
     else:
         json_files = io_utils.list_files(bin_file_dir, '.json')
+        # ignore run file
+        if run_name + '.json' in json_files:
+            json_files.remove(run_name + '.json')
     moly_fovs = []
 
     for file in json_files:

--- a/toffy/json_utils_test.py
+++ b/toffy/json_utils_test.py
@@ -76,6 +76,9 @@ def test_list_moly_fovs(tmpdir):
         with open(json_path, 'w') as jp:
             json.dump(tissue_json, jp)
 
+    # run file json
+    _make_blank_file(tmpdir, os.path.basename(tmpdir) + '.json')
+
     pred_moly_fovs = json_utils.list_moly_fovs(tmpdir)
 
     assert np.array_equal(pred_moly_fovs.sort(), moly_fovs.sort())


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Closes #268.

**How did you implement your changes**
Checks if fov_list is empty before passing to `list_moly_fovs`. 
Also add logic to ignore the run file when checking all json files in the directory for moly indicator. It hasn't caused any issues yet, but technically we don't need to be reading in that large json file. 
