### PR TITLE
Make sure loading in convert_panel happens in utf-8

### DIFF
--- a/toffy/panel_utils.py
+++ b/toffy/panel_utils.py
@@ -57,7 +57,7 @@ def convert_panel(panel_path):
 
     # read in metadata contained in the first few lines
     col_index = 0
-    with open(panel_path) as r:
+    with open(panel_path, encoding='utf-8') as r:
         lines = r.readlines()
         for index, line in enumerate(lines):
             # line containing the column names we want


### PR DESCRIPTION
**What is the purpose of this PR?**

This [line](https://github.com/angelolab/toffy/blob/5732d81255ca164f35add155493416a87e9db2bf/toffy/panel_utils.py#L60) in `panel_utils.py` does not explicitly specify `utf-8` encoding. This can lead to errors when `readlines` is called, such as that in #245.

**How did you implement your changes**

Specify `encoding='utf-8'` in the `open` call.