### PR TITLE
Add link in notebooks for the ark tiled Image Stitching script

### DIFF
--- a/templates/2_create_tiled_mibi_run.ipynb
+++ b/templates/2_create_tiled_mibi_run.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "### Background\n",
     "\n",
-    "This notebook allows you to automatically set up large tiled runs of contiguous FOVs. You can specify the dimensions of the tiled image, for example 5x5, and select specific FOVs you wish to exclude from the final tile.\n",
+    "This notebook allows you to automatically set up large tiled runs of contiguous FOVs. You can specify the dimensions of the tiled image, for example 5x5, and select specific FOVs you wish to exclude from the final tile. To stitch these FOV images back into their tiled shape later, use the [Image Stitching notebook](https://github.com/angelolab/ark-analysis/blob/main/templates/Image_Stitching.ipynb) in the ark-analysis repo.\n",
     "\n",
     "The script expects that you have already generated and moved the necessary files into the appropriate directory before starting.\n",
     "\n",
@@ -206,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -220,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/templates/3e_stitch_images.ipynb
+++ b/templates/3e_stitch_images.ipynb
@@ -8,7 +8,7 @@
     "# Stitch Images Notebook\n",
     "## This notebook is an example: create a copy before running it or you will get merge conflicts!\n",
     "\n",
-    "This notebook will create a single stitched image for each channel in your panel across all of the FOVs in your run, allowing you to quickly inspect your data. \n",
+    "This notebook will create a single stitched image for each channel in your panel across all of the FOVs in your run, allowing you to quickly inspect your data. Images will be stitched together based on acquisition order. If you would like to generate images based on the original tiled shape specified in [2_create_tiled_mibi_run](./2_create_tiled_mibi_run.ipynb), use the [Image Stitching notebook](https://github.com/angelolab/ark-analysis/blob/main/templates/Image_Stitching.ipynb) in the ark-analysis repo instead.\n",
     "\n",
     "**If you have not already extracted your images, please run notebook [3b_extract_images_from_bin](./3b_extract_images_from_bin.ipynb).**"
    ]


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Closes #276.
Adds a link to the ark Image Stitching notebook (designed for tiled runs) to both the `2_create_tiled_mibi_run` and `3e_stitch_images` notebooks.

**Remaining issues**

Should we also point them towards section 1 of the `5_rename_and_reorganize` notebook to copy and rename the fov folders? 