### PR TITLE
Tiled stitching for toffy

### DIFF
--- a/templates/3e_stitch_images.ipynb
+++ b/templates/3e_stitch_images.ipynb
@@ -8,7 +8,7 @@
     "# Stitch Images Notebook\n",
     "## This notebook is an example: create a copy before running it or you will get merge conflicts!\n",
     "\n",
-    "This notebook will create a single stitched image for each channel in your panel across all of the FOVs in your run, allowing you to quickly inspect your data. Images will be stitched together based on acquisition order. If you would like to generate images based on the original tiled shape specified in [2_create_tiled_mibi_run](./2_create_tiled_mibi_run.ipynb), use the [Image Stitching notebook](https://github.com/angelolab/ark-analysis/blob/main/templates/Image_Stitching.ipynb) in the ark-analysis repo instead.\n",
+    "This notebook will create a single stitched image for each channel in your panel across all of the FOVs in your run, allowing you to quickly inspect your data. By default, images will be stitched together based on acquisition order. If you would like to generate images based on the original tiled shape specified in [2_create_tiled_mibi_run](./2_create_tiled_mibi_run.ipynb), make sure to specify so with `tiled_image=True`.\n",
     "\n",
     "**If you have not already extracted your images, please run notebook [3b_extract_images_from_bin](./3b_extract_images_from_bin.ipynb).**"
    ]
@@ -41,9 +41,10 @@
    "metadata": {},
    "source": [
     "## Required variables\n",
-    "You will need to define the run name argument for this notebook, with two optional arguments.\n",
+    "You will need to define the run name argument for this notebook, with three optional arguments.\n",
     " - `run_name` should contain the exact name of the MIBI run to stitch images for\n",
     " <br> <br>\n",
+    "  - `tiled_image` whether the image should be stitched together into the original tiled FOV shape (as specified in [2_create_tiled_mibi_run](./2_create_tiled_mibi_run.ipynb))\n",
     " - `sub_dir` optional name of image sub-folder within each fov, if not applicable leave as None\n",
     " - `channel_list` optional channel list specifying which to stitch images for, when left as None will run on all extracted channels "
    ]
@@ -58,6 +59,7 @@
     "# the name of the run\n",
     "run_name = 'YYYY-MM-DD_run_name'\n",
     "\n",
+    "tiled_image = False\n",
     "sub_dir = None\n",
     "channel_list = None"
    ]
@@ -69,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# path to directory containing the run file,\n",
+    "# path to directory containing the run file, required for tiled images\n",
     "# can be set to None if there's no run file for the images you're stitching\n",
     "base_dir = os.path.join('D:\\\\Data', run_name) \n",
     "\n",
@@ -83,7 +85,7 @@
    "metadata": {},
    "source": [
     "## Stitch Images\n",
-    "Stitched images are saved to the subdirectory `D:\\\\Extracted_Images\\\\run_name\\\\stitched_images`."
+    "Stitched images are saved to the subdirectory `D:\\\\Extracted_Images\\\\run_name\\\\stitched_images` (or `\\\\stitched_images_tiled`)."
    ]
   },
   {
@@ -93,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stitch_images(extraction_dir, base_dir, channels=channel_list, img_sub_folder=sub_dir)"
+    "stitch_images(extraction_dir, base_dir, channels=channel_list, img_sub_folder=sub_dir, tiled=tiled_image)"
    ]
   }
  ],

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -62,7 +62,7 @@ def get_max_img_size(tiff_out_dir, img_sub_folder='', run_dir=None, fov_list=Non
 def get_tiled_names(fov_list, run_dir):
     """Retrieves the original tiled name for each fov
         Args:
-            fov_list (list): list of fovs
+            fov_list (list): list of fovs that have an existing image dir
             run_dir (str): path to the run directory containing the run json file
         Returns:
             dictionary with RnCm name as keys and the fov-x-scan-1 name as values"""
@@ -96,6 +96,10 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
             channels (list): list of channels to produce stitched images for, None will do all
             img_sub_folder (str): optional name of image sub-folder within each fov
             tiled (bool): whether to stitch images back into original tiled shape """
+
+    io_utils.validate_paths(tiff_out_dir)
+    if run_dir:
+        io_utils.validate_paths(run_dir)
 
     # check for previous stitching
     stitched_dir = os.path.join(tiff_out_dir, 'stitched_images')
@@ -151,4 +155,4 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
         stitched = data_utils.stitch_images(image_data, num_cols)
         current_img = stitched.loc['stitched_image', :, :, chan].values
         fname = os.path.join(stitched_dir, chan + "_stitched.tiff")
-        save_image(fname, current_img.astype("float32"))
+        save_image(fname, current_img)

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -83,7 +83,9 @@ def get_tiled_names(fov_list, run_dir):
         if default_name in fov_list:
             # get tiled name
             tiled_name = fov.get('name')
-            fov_names[tiled_name] = default_name
+            # filter out moly fovs
+            if tiled_name != 'MoQC':
+                fov_names[tiled_name] = default_name
 
     return fov_names
 
@@ -130,8 +132,6 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
     # get load and stitching args
     if tiled:
         folders_dict = get_tiled_names(folders, run_dir)
-        if 'MoQC' in list(folders_dict.keys()):
-            folders_dict.pop('MoQC')
         # returns a dict with keys RnCm and values og folder names
         try:
             expected_fovs, num_rows, num_cols = load_utils.get_tiled_fov_names(

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -59,18 +59,53 @@ def get_max_img_size(tiff_out_dir, img_sub_folder='', run_dir=None, fov_list=Non
     return max_img_size
 
 
-def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None):
+def get_tiled_names(fov_list, run_dir):
+    """Retrieves the original tiled name for each fov
+        Args:
+            fov_list (list): list of fovs
+            run_dir (str): path to the run directory containing the run json file
+        Returns:
+            dictionary with RnCm name as keys and the fov-x-scan-1 name as values"""
+
+    run_name = os.path.basename(run_dir)
+    run_file_path = os.path.join(run_dir, run_name + '.json')
+    fov_names = {}
+
+    # check for a run file
+    io_utils.validate_paths(run_file_path)
+
+    # retrieve all tiled fov names
+    run_data = json_utils.read_json_file(run_file_path)
+    for fov in run_data['fovs']:
+        run_order = fov.get('runOrder')
+        default_name = f'fov-{run_order}-scan-1'
+
+        if default_name in fov_list:
+            # get tiled name
+            tiled_name = fov.get('name')
+            fov_names[tiled_name] = default_name
+
+    return fov_names
+
+
+def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None, tiled=False):
     """Creates a new directory containing stitched channel images for the run
         Args:
             tiff_out_dir (str): path to the extracted images for the specific run
             run_dir (str): path to the run directory containing the run json files, default None
             channels (list): list of channels to produce stitched images for, None will do all
-            img_sub_folder (str): optional name of image sub-folder within each fov"""
+            img_sub_folder (str): optional name of image sub-folder within each fov
+            tiled (bool): whether to stitch images back into original tiled shape """
 
     # check for previous stitching
     stitched_dir = os.path.join(tiff_out_dir, 'stitched_images')
+    if tiled:
+        stitched_dir = os.path.join(tiff_out_dir, 'stitched_images_tiled')
+        if run_dir is None:
+            raise ValueError("You must provide the run directory to stitch images into their "
+                             "original tiled shape.")
     if os.path.exists(stitched_dir):
-        raise ValueError(f"fThe stitch_images subdirectory already exists in {tiff_out_dir}")
+        raise ValueError(f"The stitch_images subdirectory already exists in {tiff_out_dir}")
 
     folders = io_utils.list_folders(tiff_out_dir, substrs='fov-')
     folders = ns.natsorted(folders)
@@ -89,17 +124,30 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
                                 substrs='.tiff')))
 
     # get load and stitching args
-    num_cols = math.isqrt(len(folders))
-    max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)
+    if tiled:
+        folders_dict = get_tiled_names(folders, run_dir)
+        # returns a dict with keys RnCm and values og folder names
+        expected_fovs, num_rows, num_cols = load_utils.get_tiled_fov_names(
+            list(folders_dict.keys()), return_dims=True)
+    else:
+        num_cols = math.isqrt(len(folders))
+        max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)
 
     # make stitched subdir
     os.makedirs(stitched_dir)
 
     # save the stitched images to the stitched_image subdir
     for chan in channels:
-        image_data = load_utils.load_imgs_from_tree(tiff_out_dir, img_sub_folder=img_sub_folder,
-                                                    fovs=folders, channels=[chan],
-                                                    max_image_size=max_img_size)
+        # tiled image loading
+        if tiled:
+            image_data = load_utils.load_tiled_img_data(tiff_out_dir, folders_dict, expected_fovs,
+                                                        chan, single_dir=False,
+                                                        img_sub_folder=img_sub_folder)
+        else:
+            image_data = load_utils.load_imgs_from_tree(tiff_out_dir,
+                                                        img_sub_folder=img_sub_folder,
+                                                        fovs=folders, channels=[chan],
+                                                        max_image_size=max_img_size)
         stitched = data_utils.stitch_images(image_data, num_cols)
         current_img = stitched.loc['stitched_image', :, :, chan].values
         fname = os.path.join(stitched_dir, chan + "_stitched.tiff")

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -130,6 +130,8 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
     # get load and stitching args
     if tiled:
         folders_dict = get_tiled_names(folders, run_dir)
+        if 'MoQC' in list(folders_dict.keys()):
+            folders_dict.pop('MoQC')
         # returns a dict with keys RnCm and values og folder names
         try:
             expected_fovs, num_rows, num_cols = load_utils.get_tiled_fov_names(

--- a/toffy/image_stitching.py
+++ b/toffy/image_stitching.py
@@ -131,8 +131,11 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
     if tiled:
         folders_dict = get_tiled_names(folders, run_dir)
         # returns a dict with keys RnCm and values og folder names
-        expected_fovs, num_rows, num_cols = load_utils.get_tiled_fov_names(
-            list(folders_dict.keys()), return_dims=True)
+        try:
+            expected_fovs, num_rows, num_cols = load_utils.get_tiled_fov_names(
+                list(folders_dict.keys()), return_dims=True)
+        except AttributeError:
+            raise ValueError(f'FOV names found in the run file were not in tiled (RnCm) format.')
     else:
         num_cols = math.isqrt(len(folders))
         max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -4,26 +4,37 @@ import pytest
 import shutil
 
 from toffy import image_stitching, json_utils
-from ark.utils import io_utils, test_utils
+from ark.utils import io_utils, test_utils, load_utils
+
+
+RUN_JSON_SPOOF = {
+        'fovs': [
+            {'runOrder': 1, 'scanCount': 1, 'frameSizePixels': {'width': 32, 'height': 32},
+             'name': 'R1C3'},
+            {'runOrder': 2, 'scanCount': 1, 'frameSizePixels': {'width': 16, 'height': 16},
+             'name': 'R2C1'},
+            {'runOrder': 3, 'scanCount': 1, 'frameSizePixels': {'width': 8, 'height': 8},
+             'name': 'R1C1'},
+            {'runOrder': 4, 'scanCount': 1, 'frameSizePixels': {'width': 16, 'height': 16},
+             'name': 'R2C2'},
+        ],
+    }
+
+
+def make_run_file(tmp_dir):
+    test_dir = os.path.join(tmp_dir, 'data', 'test_run')
+    os.makedirs(test_dir)
+    json_path = os.path.join(test_dir, 'test_run.json')
+    json_utils.write_json_file(json_path, RUN_JSON_SPOOF)
+
+    return test_dir
 
 
 def test_get_max_img_size():
 
-    RUN_JSON_SPOOF = {
-        'fovs': [
-            {'runOrder': 1, 'scanCount': 1, 'frameSizePixels': {'width': 32, 'height': 32}},
-            {'runOrder': 2, 'scanCount': 1, 'frameSizePixels': {'width': 16, 'height': 16}},
-            {'runOrder': 3, 'scanCount': 1, 'frameSizePixels': {'width': 8, 'height': 8}},
-            {'runOrder': 4, 'scanCount': 1, 'frameSizePixels': {'width': 16, 'height': 16}},
-        ],
-    }
-
     # test with run file
     with tempfile.TemporaryDirectory() as tmp_dir:
-        test_dir = os.path.join(tmp_dir, 'data', 'test_run')
-        os.makedirs(test_dir)
-        json_path = os.path.join(test_dir, 'test_run.json')
-        json_utils.write_json_file(json_path, RUN_JSON_SPOOF)
+        test_dir = make_run_file(tmp_dir)
 
         # test success for all fovs
         max_img_size = image_stitching.get_max_img_size('extracted_dir', run_dir=test_dir)
@@ -66,7 +77,30 @@ def test_get_max_img_size():
         assert max_img_size == 32
 
 
-def test_stitch_images(mocker):
+def test_get_tiled_names():
+
+    # test with run file
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        test_dir = make_run_file(tmp_dir)
+
+        fov_list = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-3-scan-1', 'fov-4-scan-1']
+        tiled_names = ['R1C3', 'R2C1', 'R1C1', 'R2C2']
+
+        fov_names = image_stitching.get_tiled_names(fov_list, test_dir)
+        assert list(fov_names.values()) == fov_list
+        assert list(fov_names.keys()) == tiled_names
+
+        # check for subset of fovs in run that actually have image dirs
+        fov_list = ['fov-1-scan-1', 'fov-3-scan-1']
+        tiled_names = ['R1C3', 'R1C1']
+
+        fov_names = image_stitching.get_tiled_names(fov_list, test_dir)
+        assert list(fov_names.values()) == fov_list
+        assert list(fov_names.keys()) == tiled_names
+
+
+@pytest.mark.parametrize('tiled', [False, True])
+def test_stitch_images(mocker, tiled):
     mocker.patch('toffy.image_stitching.get_max_img_size', return_value=32)
 
     channel_list = ['Au', 'CD3', 'CD4', 'CD8', 'CD11c']
@@ -74,40 +108,63 @@ def test_stitch_images(mocker):
                      'CD8_stitched.tiff', 'CD11c_stitched.tiff']
     fov_list = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-3-scan-1']
 
+    if tiled:
+        stitched_dir = 'stitched_images_tiled'
+    else:
+        stitched_dir = 'stitched_images'
+
     with tempfile.TemporaryDirectory() as tmpdir:
+        test_dir = make_run_file(tmpdir)
         test_utils._write_tifs(tmpdir, fov_list, channel_list, (10, 10), '', False, int)
 
         # bad channel should raise an error
         with pytest.raises(ValueError, match='Not all values given in list channel inputs were '
                                              'found in list valid channels.'):
-            image_stitching.stitch_images(tmpdir, tmpdir, ['Au', 'bad_channel'])
+            image_stitching.stitch_images(tmpdir, test_dir, ['Au', 'bad_channel'], tiled=tiled)
 
         # test successful stitching for all channels
-        image_stitching.stitch_images(tmpdir, tmpdir)
-        assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
+        image_stitching.stitch_images(tmpdir, test_dir, tiled=tiled)
+        assert sorted(io_utils.list_files(os.path.join(tmpdir, stitched_dir))) == \
                sorted(stitched_tifs)
+        data = load_utils.load_imgs_from_dir(os.path.join(tmpdir, stitched_dir),
+                                             files=['Au_stitched.tiff'])
+        # img size 10 for tiled grid 2x3
+        if tiled:
+            assert data.shape == (1, 20, 30, 1)
+        # max img size 32  with 4 acquired fovs
+        else:
+            assert data.shape == (1, 96, 32, 1)
 
         # test previous stitching raises an error
         with pytest.raises(ValueError, match="The stitch_images subdirectory already exists"):
-            image_stitching.stitch_images(tmpdir, tmpdir)
-        shutil.rmtree(os.path.join(tmpdir, 'stitched_images'))
+            image_stitching.stitch_images(tmpdir, test_dir, tiled=tiled)
+        shutil.rmtree(os.path.join(tmpdir, stitched_dir))
 
         # test stitching for specific channels
-        image_stitching.stitch_images(tmpdir, channels=['Au', 'CD3'])
-        assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
+        image_stitching.stitch_images(tmpdir, test_dir, channels=['Au', 'CD3'], tiled=tiled)
+        assert sorted(io_utils.list_files(os.path.join(tmpdir, stitched_dir))) == \
                sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])
-        shutil.rmtree(os.path.join(tmpdir, 'stitched_images'))
+        shutil.rmtree(os.path.join(tmpdir, stitched_dir))
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        test_dir = make_run_file(tmpdir)
+        test_utils._write_tifs(tmpdir, fov_list, channel_list, (10, 10), '', False, int)
         test_utils._write_tifs(tmpdir, fov_list, channel_list, (10, 10), 'sub_dir', False, int)
 
         # test stitching for images in subdir
-        image_stitching.stitch_images(tmpdir, tmpdir, ['Au', 'CD3'], img_sub_folder='sub_dir')
-        assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
+        image_stitching.stitch_images(tmpdir, test_dir, ['Au', 'CD3'], img_sub_folder='sub_dir',
+                                      tiled=tiled)
+        assert sorted(io_utils.list_files(os.path.join(tmpdir, stitched_dir))) == \
                sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])
-        shutil.rmtree(os.path.join(tmpdir, 'stitched_images'))
+        shutil.rmtree(os.path.join(tmpdir, stitched_dir))
 
         # test stitching for no run_dir
-        image_stitching.stitch_images(tmpdir, channels=['Au', 'CD3'], img_sub_folder='sub_dir')
-        assert sorted(io_utils.list_files(os.path.join(tmpdir, 'stitched_images'))) == \
-               sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])
+        if not tiled:
+            image_stitching.stitch_images(tmpdir, channels=['Au', 'CD3'], img_sub_folder='sub_dir',
+                                          tiled=tiled)
+            assert sorted(io_utils.list_files(os.path.join(tmpdir, stitched_dir))) == \
+                   sorted(['Au_stitched.tiff', 'CD3_stitched.tiff'])
+        else:
+            with pytest.raises(ValueError):
+                image_stitching.stitch_images(tmpdir, channels=['Au', 'CD3'],
+                                              img_sub_folder='sub_dir', tiled=tiled)

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -22,6 +22,8 @@ RUN_JSON_SPOOF = {
 
 
 def make_run_file(tmp_dir):
+    """Create a run subir and run json in the provided dir and return the path to this new dir."""
+
     test_dir = os.path.join(tmp_dir, 'data', 'test_run')
     os.makedirs(test_dir)
     json_path = os.path.join(test_dir, 'test_run.json')
@@ -148,7 +150,6 @@ def test_stitch_images(mocker, tiled):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         test_dir = make_run_file(tmpdir)
-        test_utils._write_tifs(tmpdir, fov_list, channel_list, (10, 10), '', False, int)
         test_utils._write_tifs(tmpdir, fov_list, channel_list, (10, 10), 'sub_dir', False, int)
 
         # test stitching for images in subdir

--- a/toffy/image_stitching_test.py
+++ b/toffy/image_stitching_test.py
@@ -14,7 +14,7 @@ RUN_JSON_SPOOF = {
             {'runOrder': 2, 'scanCount': 1, 'frameSizePixels': {'width': 16, 'height': 16},
              'name': 'R2C1'},
             {'runOrder': 3, 'scanCount': 1, 'frameSizePixels': {'width': 8, 'height': 8},
-             'name': 'R1C1'},
+             'name': 'MoQC'},
             {'runOrder': 4, 'scanCount': 1, 'frameSizePixels': {'width': 16, 'height': 16},
              'name': 'R2C2'},
         ],
@@ -85,16 +85,16 @@ def test_get_tiled_names():
     with tempfile.TemporaryDirectory() as tmp_dir:
         test_dir = make_run_file(tmp_dir)
 
-        fov_list = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-3-scan-1', 'fov-4-scan-1']
-        tiled_names = ['R1C3', 'R2C1', 'R1C1', 'R2C2']
+        fov_list = ['fov-1-scan-1', 'fov-2-scan-1', 'fov-4-scan-1']
+        tiled_names = ['R1C3', 'R2C1', 'R2C2']
 
         fov_names = image_stitching.get_tiled_names(fov_list, test_dir)
         assert list(fov_names.values()) == fov_list
         assert list(fov_names.keys()) == tiled_names
 
         # check for subset of fovs in run that actually have image dirs
-        fov_list = ['fov-1-scan-1', 'fov-3-scan-1']
-        tiled_names = ['R1C3', 'R1C1']
+        fov_list = ['fov-1-scan-1', 'fov-4-scan-1']
+        tiled_names = ['R1C3', 'R2C2']
 
         fov_names = image_stitching.get_tiled_names(fov_list, test_dir)
         assert list(fov_names.values()) == fov_list


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #279. Gives users the option to stitch images by original tiled shape rather than just acquisition order. 

**How did you implement your changes**

Detailed in https://github.com/angelolab/ark-analysis/issues/795. Adds a helper function to get the RnCm names from the run file and store them in a dictionary along with their corresponding default fov name. Adjusts `image_stitching.stitch_images()` to have a tiled bool arg and updated the notebook accordingly.

**Remaining issues**
There's a logic issue if a fov has more than one scan, but for tiled runs I don't think that should be an issue (?). Right now it only loads in the first scan for each fov.
