### PR TITLE
Skip empty json files in voltage check

### DIFF
--- a/toffy/normalize.py
+++ b/toffy/normalize.py
@@ -20,7 +20,7 @@ from mibi_bin_tools.io_utils import remove_file_extensions
 from mibi_bin_tools.bin_files import extract_bin_files, get_median_pulse_height
 from mibi_bin_tools.panel_utils import make_panel
 from tmi.image_utils import save_image
-from toffy.json_utils import read_json_file, write_json_file
+from toffy.json_utils import read_json_file, write_json_file, check_for_empty_files
 
 
 def write_counts_per_mass(base_dir, output_dir, fov, masses, start_offset=0.5,
@@ -729,8 +729,12 @@ def check_detector_voltage(run_dir):
     """
 
     fovs = remove_file_extensions(io_utils.list_files(run_dir, substrs='.bin'))
-    fovs = ns.natsorted(fovs)
     changes_in_voltage = []
+
+    # skip any damaged fovs
+    empty_fovs = check_for_empty_files(run_dir)
+    fovs = list(set(fovs).difference(empty_fovs))
+    fovs = ns.natsorted(fovs)
 
     # check for voltage changes and add to list of dictionaries
     for i, fov in enumerate(fovs):

--- a/toffy/normalize_test.py
+++ b/toffy/normalize_test.py
@@ -560,6 +560,12 @@ def test_check_detector_voltage():
             write_json_file(json_path, fov_data)
 
         # constant voltage should run smoothly
+        normalize.check_detector_voltage(tmp_dir)
+
+        # skip empty json files
+        test_utils._make_blank_file(tmp_dir, 'fov-0.bin')
+        test_utils._make_blank_file(tmp_dir, 'fov-0.json')
+        with pytest.warns(UserWarning, match='The following FOVs have empty json files'):
             normalize.check_detector_voltage(tmp_dir)
 
         for i in list(range(4, 11)):


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**
Closes #289.

**How did you implement your changes**
Implement the `check_for_empty_files` within the `check_detector_voltage` function.

