### PR TITLE
Make sure Rosetta converts images to `float` prior to running

### DIFF
--- a/toffy/rosetta.py
+++ b/toffy/rosetta.py
@@ -247,6 +247,9 @@ def compensate_image_data(raw_data_dir, comp_data_dir, comp_mat_path, panel_info
                                                     channels=acquired_targets,
                                                     img_sub_folder=raw_data_sub_folder)
 
+        # convert to float32 for gaussian_filter and rosetta compatibility
+        batch_data = batch_data.astype(np.float32)
+
         # blur data
         if gaus_rad > 0:
             for j in range(batch_data.shape[0]):

--- a/toffy/rosetta_test.py
+++ b/toffy/rosetta_test.py
@@ -199,7 +199,7 @@ def test_compensate_image_data(output_masses, input_masses, gaus_rad, save_forma
         # make fake data for testing
         fovs, chans = test_utils.gen_fov_chan_names(num_fovs=3, num_chans=3)
         filelocs, data_xr = test_utils.create_paired_xarray_fovs(
-            data_dir, fovs, chans, img_shape=(10, 10), fills=True, dtype=np.float64)
+            data_dir, fovs, chans, img_shape=(10, 10), fills=True, dtype=np.uint32)
         os.makedirs(os.path.join(data_dir, 'stitched_images'))
 
         # create compensation matrix


### PR DESCRIPTION
**What is the purpose of this PR?**

Addresses #288 and closes #292. Because the functionality of `load_imgs_from_tree` was updated to not use explicit `dtype` loading, cohorts of `uint32` will not work due to floating point incompatibilities  caused by channel coefficient subtraction. This `dtype` gets propagated through functions such as `gaussian_filter` rather than being corrected.

We'll need to add an explicit correction for this loading prior to running them through Rosetta

**How did you implement your changes**

Since we can't tell `load_imgs_from_tree` which `dtype` to use, we'll instead add an explicit `.astype(np.float32)` cast right after the call.
