### PR TITLE
Don't display warning if the watcher discovers a temp file

### DIFF
--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -74,6 +74,10 @@ class RunStructure:
 
         filename = Path(path).parts[-1]
 
+        # if filename starts with a '.' (temp file), it should be ignored
+        if filename[0] == ".":
+            return False, ""
+
         # filename is not corrct format of fov.bin or fov.json
         if len(filename.split(".")) != 2:
             warnings.warn(


### PR DESCRIPTION
**What is the purpose of this PR?**

During a MIBI run, numerous temp files may appear. These are generally prefixed with `.` and are used as intermediate steps (ex. to the final `.bin` file). While the watcher may pick up on these files, they should not be reported as extraneous files to the user.

**How did you implement your changes**

Add a check at the beginning of `check_run_condition` that immediately returns out with `False` if the filename detected starts with a `.`.

**Remaining issues**

This does not completely solve an issue @ngreenwald ran into where the watcher did not ever report the corresponding `.bin` file. However, this may be related, as `.bin` files can also be originally written out in the format `.fov-{fov_num}-scan-{scan_num}.bin.{6_letter_hash}` before being copied over in its final `.bin` state.