### PR TITLE
Missing import in extraction notebook

### DIFF
--- a/templates/3b_extract_images_from_bin.ipynb
+++ b/templates/3b_extract_images_from_bin.ipynb
@@ -14,12 +14,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "57186f2e-8030-436d-85ff-b4a3aa4a446f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "import sys\n",
+    "import os\n",
     "\n",
     "from toffy.panel_utils import load_panel\n",
     "from toffy.bin_extraction import extract_missing_fovs"
@@ -38,9 +40,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "2726b808-9378-41e5-a8d1-788a693e6937",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# set up args for current run\n",
@@ -60,11 +64,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6ffdb7b9-40d3-46a1-96c2-17bfa3605774",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# read in panel information\n",
-    "panel = load_panel(panel_path)\n",
+    "#panel = load_panel(panel_path)\n",
     "\n",
     "# path to the directory containing the FOV bin files\n",
     "base_dir = os.path.join('D:\\\\Data', run_name) \n",
@@ -97,7 +103,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -111,7 +117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/templates/3b_extract_images_from_bin.ipynb
+++ b/templates/3b_extract_images_from_bin.ipynb
@@ -70,7 +70,7 @@
    "outputs": [],
    "source": [
     "# read in panel information\n",
-    "#panel = load_panel(panel_path)\n",
+    "panel = load_panel(panel_path)\n",
     "\n",
     "# path to the directory containing the FOV bin files\n",
     "base_dir = os.path.join('D:\\\\Data', run_name) \n",


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Somehow we are missing an os import statement at the top of notebook 3b.

**How did you implement your changes**

`import os`

**Remaining issues**

Find the culprit.
