### PR TITLE
Update `axes_size` to `axes_font_size` in `3c` notebook

### DIFF
--- a/templates/3c_generate_qc_metrics.ipynb
+++ b/templates/3c_generate_qc_metrics.ipynb
@@ -208,7 +208,7 @@
     "qc_comp.visualize_qc_metrics(\n",
     "    qc_metric,\n",
     "    qc_out_dir,\n",
-    "    axes_size=16,\n",
+    "    axes_font_size=16,\n",
     "    wrap=6,\n",
     "    dpi=None,\n",
     "    save_dir=plot_dir\n",
@@ -218,7 +218,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "toffy38",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -232,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.8.15"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #336. `visualize_qc_metrics` now takes `axes_font_size` instead of `axes_size` as a param. This change needs to be reflected in notebook 3c.

**How did you implement your changes**

Change the parameter name.