### PR TITLE
Fix median pulse height chart drawn by `visualize_mph`

### DIFF
--- a/src/toffy/mph_comp.py
+++ b/src/toffy/mph_comp.py
@@ -153,7 +153,7 @@ def visualize_mph(mph_df, out_dir, regression: bool = False):
         io_utils.validate_paths(out_dir)
 
     # visualize the median pulse heights
-    plt.title("FOV total counts vs median pulse height")
+    plt.style.use("dark_background")
     fig = plt.figure()
     ax1 = fig.add_subplot(111)
     x = mph_df["cum_total_count"] / 1000000
@@ -163,6 +163,7 @@ def visualize_mph(mph_df, out_dir, regression: bool = False):
     ax1.scatter(x, y)
     ax2 = ax1.twiny()
     ax2.set_xlabel("estimated time (hours)")
+    plt.title("FOV total counts vs median pulse height")
 
     # create time axis
     new_ticks = generate_time_ticks(mph_df)

--- a/src/toffy/mph_comp.py
+++ b/src/toffy/mph_comp.py
@@ -153,7 +153,6 @@ def visualize_mph(mph_df, out_dir, regression: bool = False):
         io_utils.validate_paths(out_dir)
 
     # visualize the median pulse heights
-    plt.style.use("dark_background")
     fig = plt.figure()
     ax1 = fig.add_subplot(111)
     x = mph_df["cum_total_count"] / 1000000


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #337. The plot for median pulse height is being drawn incorrectly, adding a ghost figure on top. This is due to the placement of `plt.title`, which draws an additional plot when called before `fig.add_subplot`.

**How did you implement your changes**

Add `plt.title` after defining `ax1` and `ax2`.

For some reason the `plt.style.use("dark_background")` call got removed. I quite like dark mode for this graph so it's been added back in 😊.

Simulated plot:

<img width="845" alt="Screenshot 2023-04-13 at 12 47 21 PM" src="https://user-images.githubusercontent.com/31424707/231867241-952caf78-c9bb-4cd7-ad83-2fd7960ec10f.png">