### PR TITLE
Add functionality to catch file renaming to watcher

### DIFF
--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -208,7 +208,7 @@ class FOV_EventHandler(FileSystemEventHandler):
             for name in files:
                 self.on_created(FileCreatedEvent(os.path.join(root, name)))
 
-    def _callback_runner(self, event: Union[FileCreatedEvent, FileMovedEvent]):
+    def _run_callbacks(self, event: Union[FileCreatedEvent, FileMovedEvent]):
         # check if what's created is in the run structure
         try:
             fov_ready, point_name = self.run_structure.check_run_condition(event.src_path)
@@ -256,7 +256,7 @@ class FOV_EventHandler(FileSystemEventHandler):
                 file creation event
         """
         super().on_created(event)
-        self._callback_runner(event)
+        self._run_callbacks(event)
 
     def on_moved(self, event: FileMovedEvent):
         """Handles file renaming events
@@ -269,7 +269,7 @@ class FOV_EventHandler(FileSystemEventHandler):
                 file creation event
         """
         super.on_moved(event)
-        self._callback_runner(event)
+        self._run_callbacks(event)
 
     def check_complete(self):
         """Checks run structure fov_progress status

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -256,92 +256,20 @@ class FOV_EventHandler(FileSystemEventHandler):
                 file creation event
         """
         super().on_created(event)
-        # self._callback_runner(event)
+        self._callback_runner(event)
 
-        # check if what's created is in the run structure
-        try:
-            fov_ready, point_name = self.run_structure.check_run_condition(event.src_path)
-        except TimeoutError as timeout_error:
-            print(f"Encountered TimeoutError error: {timeout_error}")
-            logf = open(self.log_path, "a")
-            logf.write(
-                f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- '
-                f"{event.src_path} never reached non-zero file size...\n"
-            )
-            self.check_complete()
-            return
+    def on_moved(self, event: FileMovedEvent):
+        """Handles file renaming events
 
-        if fov_ready:
-            print(f"Discovered {point_name}, beginning per-fov callbacks...")
-            logf = open(self.log_path, "a")
+        If FOV structure is completed, the fov callback, `self.fov_func` will be run over the data.
+        This function is automatically called; users generally shouldn't call this function
 
-            logf.write(
-                f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- Extracting {point_name}\n'
-            )
-
-            # run per_fov callbacks
-            logf.write(
-                f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- '
-                f"Running {self.fov_func.__name__} on {point_name}\n"
-            )
-
-            self.fov_func(self.run_folder, point_name)
-            self.run_structure.processed(point_name)
-
-            if self.inter_func:
-                self.inter_func(self.run_folder)
-
-            logf.close()
-            self.check_complete()
-
-    # def on_moved(self, event: FileMovedEvent):
-    #     """Handles file renaming events
-
-    #     If FOV structure is completed, the fov callback, `self.fov_func` will be run over the data.
-    #     This function is automatically called; users generally shouldn't call this function
-
-    #     Args:
-    #         event (FileCreatedEvent):
-    #             file creation event
-    #     """
-    #     super.on_moved(event)
-    #     self._callback_runner(event)
-
-    #     # # check if what's created is in the run structure
-    #     # try:
-    #     #     fov_ready, point_name = self.run_structure.check_run_condition(event.src_path)
-    #     # except TimeoutError as timeout_error:
-    #     #     print(f"Encountered TimeoutError error: {timeout_error}")
-    #     #     logf = open(self.log_path, "a")
-    #     #     logf.write(
-    #     #         f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- '
-    #     #         f"{event.src_path} never reached non-zero file size...\n"
-    #     #     )
-    #     #     self.check_complete()
-    #     #     return
-
-    #     # if fov_ready:
-    #     #     print(f"Discovered {point_name}, beginning per-fov callbacks...")
-    #     #     logf = open(self.log_path, "a")
-
-    #     #     logf.write(
-    #     #         f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- Extracting {point_name}\n'
-    #     #     )
-
-    #     #     # run per_fov callbacks
-    #     #     logf.write(
-    #     #         f'{datetime.now().strftime("%d/%m/%Y %H:%M:%S")} -- '
-    #     #         f"Running {self.fov_func.__name__} on {point_name}\n"
-    #     #     )
-
-    #     #     self.fov_func(self.run_folder, point_name)
-    #     #     self.run_structure.processed(point_name)
-
-    #     #     if self.inter_func:
-    #     #         self.inter_func(self.run_folder)
-
-    #     #     logf.close()
-    #     #     self.check_complete()
+        Args:
+            event (FileCreatedEvent):
+                file creation event
+        """
+        super.on_moved(event)
+        self._callback_runner(event)
 
     def check_complete(self):
         """Checks run structure fov_progress status

--- a/tests/fov_watcher_test.py
+++ b/tests/fov_watcher_test.py
@@ -53,23 +53,19 @@ def _slow_copy_sample_tissue_data(
             one_blank = False
         else:
             shutil.copy(os.path.join(COMBINED_DATA_PATH, tissue_file), dest)
-            # tissue_path = os.path.join(COMBINED_DATA_PATH, tissue_file)
-            # if temp_bin:
-            #     print("Creating a temporary bin file")
-            #     os.rename(
-            #         tissue_path,
-            #         os.path.join(COMBINED_DATA_PATH, '.' + tissue_file + '.aBcDeF')
-            #     )
-            #     tissue_path = os.path.join(COMBINED_DATA_PATH, '.' + tissue_file + '.aBcDeF')
-            # print("Copying tissue data over")
-            # shutil.copy(tissue_path, dest)
+            tissue_path = os.path.join(COMBINED_DATA_PATH, tissue_file)
+            if temp_bin:
+                os.rename(
+                    tissue_path, os.path.join(COMBINED_DATA_PATH, "." + tissue_file + ".aBcDeF")
+                )
+                tissue_path = os.path.join(COMBINED_DATA_PATH, "." + tissue_file + ".aBcDeF")
+            shutil.copy(tissue_path, dest)
 
-            # # handle renaming
-            # if temp_bin:
-            #     print("Renaming tissue file")
-            #     time.sleep(delta)
-            #     copied_tissue_path = os.path.join(dest, '.' + tissue_file + '.aBcDeF')
-            #     os.rename(copied_tissue_path, os.path.join(dest, tissue_file))
+            # handle renaming
+            if temp_bin:
+                time.sleep(delta)
+                copied_tissue_path = os.path.join(dest, "." + tissue_file + ".aBcDeF")
+                os.rename(copied_tissue_path, os.path.join(dest, tissue_file))
 
 
 COMBINED_RUN_JSON_SPOOF = {


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #339. To address the issue of temp bin files and their later renaming, add watcher functionality that can record these events.

**How did you implement your changes**

Add an `on_moved` method to `FOV_EventHandler` which makes use of `watchdog.on_moved` events (handled by `FileMovedEvent`). Other than this, the process is exactly the same as `on_created`, so abstract shared functionality to `_run_callbacks`.

`_slow_copy_sample_tissue_data`, the watcher simulator, also includes a process to first generate the temp `.bin` file in `dest`, wait one second, then rename it. This reenacts what actually happens on the CACs.

**Remaining issues**

We will need to test this on an in-process run (and not one that has already been completed).