### PR TITLE
Add a scale factor for `image_stitching.stitch_images` for Photoshop compatibility

### DIFF
--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -193,7 +193,7 @@ def stitch_images(
                 )
                 fname = os.path.join(tile_stitched_dir, chan + "_stitched.tiff")
                 stitched = data_utils.stitch_images(image_data, num_cols)
-                current_img = stitched.loc["stitched_image", :, :, chan].values
+                current_img = stitched.loc["stitched_image", :, :, chan].values / scale
                 image_utils.save_image(fname, current_img)
 
         else:
@@ -206,5 +206,5 @@ def stitch_images(
             )
             fname = os.path.join(stitched_dir, chan + "_stitched.tiff")
             stitched = data_utils.stitch_images(image_data, num_cols)
-            current_img = stitched.loc["stitched_image", :, :, chan].values / 200
+            current_img = stitched.loc["stitched_image", :, :, chan].values / scale
             image_utils.save_image(fname, current_img)

--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -93,14 +93,18 @@ def get_tiled_names(fov_list, run_dir):
     return fov_names
 
 
-def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None, tiled=False):
+def stitch_images(
+    tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None, tiled=False, scale=200
+):
     """Creates a new directory containing stitched channel images for the run
     Args:
         tiff_out_dir (str): path to the extracted images for the specific run
         run_dir (str): path to the run directory containing the run json files, default None
         channels (list): list of channels to produce stitched images for, None will do all
         img_sub_folder (str): optional name of image sub-folder within each fov
-        tiled (bool): whether to stitch images back into original tiled shape"""
+        tiled (bool): whether to stitch images back into original tiled shape
+        scale (int): how much to rescale the stitched image by, needed for Photoshop compatibility
+    """
 
     io_utils.validate_paths(tiff_out_dir)
     if run_dir:
@@ -202,5 +206,5 @@ def stitch_images(tiff_out_dir, run_dir=None, channels=None, img_sub_folder=None
             )
             fname = os.path.join(stitched_dir, chan + "_stitched.tiff")
             stitched = data_utils.stitch_images(image_data, num_cols)
-            current_img = stitched.loc["stitched_image", :, :, chan].values
+            current_img = stitched.loc["stitched_image", :, :, chan].values / 200
             image_utils.save_image(fname, current_img)

--- a/tests/image_stitching_test.py
+++ b/tests/image_stitching_test.py
@@ -96,11 +96,15 @@ def _tiled_image_check(data_tiled, data_base, num_img_row, num_img_col):
 
     # index into each tile separately, compare with the original image / 200
     while row_i < num_img_row:
+        row_start = row_i * row_size
+        row_end = (row_i + 1) * row_size
         while col_i < num_img_col:
+            col_start = col_i * col_size
+            col_end = (col_i + 1) * col_size
             data_subset = data_tiled[
                 0,
-                (row_i * row_size) : ((row_i + 1) * row_size),
-                (col_i * col_size) : ((col_i + 1) * col_size),
+                row_start:row_end,
+                col_start:col_end,
                 0,
             ].values
             data_standard = data_base[fov_i, ..., 0].values


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #355. The current stitched images are not viewable in Photoshop due to scaling issues, so we need to rescale prior to saving.

**How did you implement your changes**

In Rosetta, we scale each image down by 200 to fix this. This should also be added to the `stitch_images` function:

```
current_img = stitched.loc["stitched_image", :, :, chan].values / scale
```

`scale` is a param that gets passed to `stitch_images`. As with Rosetta, it defaults to 200.

**Remaining issues**

The extracted images themselves have the same scaling issue, but I think it's best to leave these because they get scaled later on in Rosetta.