### PR TITLE
Remove warning for .def.hist and .pro.hist files

### DIFF
--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -80,10 +80,6 @@ class RunStructure:
 
         # filename is not corrct format of fov.bin or fov.json
         if len(filename.split(".")) != 2:
-            warnings.warn(
-                f"The file {filename} is not a valid FOV file and will be skipped from processing.",
-                Warning,
-            )
             return False, ""
 
         fov_name, extension = filename.split(".")

--- a/tests/fov_watcher_test.py
+++ b/tests/fov_watcher_test.py
@@ -80,8 +80,7 @@ def test_run_structure(run_json, expected_files, recwarn):
         assert not exist and name == ""
 
         # check for invalid file format
-        with pytest.warns(Warning, match="is not a valid FOV file and will be skipped"):
-            exist, name = run_structure.check_run_condition(os.path.join(tmpdir, "fov.bin.txt"))
+        exist, name = run_structure.check_run_condition(os.path.join(tmpdir, "fov.bin.txt"))
         assert not exist and name == ""
 
         # check for fake files


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #379. Remove any warnings that get thrown for invalid file types while the watcher is running. This is specifically for .pro.hist and .def.hist files, since the watcher specifically targets those for warnings (they contain multiple '.').

**How did you implement your changes**

Remove the `warnings.warn` call in this control flow.