### PR TITLE
Tma and tiled run stitching

### DIFF
--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -154,7 +154,8 @@ def stitch_images(
     if tiled:
         # returns a dict with keys RnCm and values og folder names
         tiled_folders_dict = get_tiled_names(folders, run_dir)
-        tma_folders = ns.natsorted(list(set(folders).difference(set(tiled_folders_dict.values()))))
+        tma_folders = list(set(folders).difference(set(tiled_folders_dict.values())))
+        tma_folders = ns.natsorted(tma_folders)
         try:
             expected_tiles = load_utils.get_tiled_fov_names(
                 list(tiled_folders_dict.keys()), return_dims=True

--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -201,9 +201,11 @@ def stitch_images(
             # save to individual tma subdir
             if tma_folders:
                 folders = tma_folders
-                stitched_dir = os.path.join(stitched_dir, "TMA")
-                if not os.path.exists(stitched_dir):
-                    os.makedirs(stitched_dir)
+                stitched_subdir = os.path.join(stitched_dir, "TMA")
+                if not os.path.exists(stitched_subdir):
+                    os.makedirs(stitched_subdir)
+            else:
+                stitched_subdir = stitched_dir
 
             num_cols = math.isqrt(len(folders))
             max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)
@@ -215,7 +217,7 @@ def stitch_images(
                 channels=[chan],
                 max_image_size=max_img_size,
             )
-            fname = os.path.join(stitched_dir, chan + "_stitched.tiff")
+            fname = os.path.join(stitched_subdir, chan + "_stitched.tiff")
             stitched = data_utils.stitch_images(image_data, num_cols)
             current_img = stitched.loc["stitched_image", :, :, chan].values / scale
             image_utils.save_image(fname, current_img)

--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -150,6 +150,7 @@ def stitch_images(
         )
 
     # get load and stitching args
+    tma_folders = None
     if tiled:
         # returns a dict with keys RnCm and values og folder names
         tiled_folders_dict = get_tiled_names(folders, run_dir)

--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -152,16 +152,14 @@ def stitch_images(
     # get load and stitching args
     if tiled:
         # returns a dict with keys RnCm and values og folder names
-        folders_dict = get_tiled_names(folders, run_dir)
+        tiled_folders_dict = get_tiled_names(folders, run_dir)
+        tma_folders = ns.natsorted(list(set(folders).difference(set(tiled_folders_dict.values()))))
         try:
             expected_tiles = load_utils.get_tiled_fov_names(
-                list(folders_dict.keys()), return_dims=True
+                list(tiled_folders_dict.keys()), return_dims=True
             )
         except AttributeError:
             raise ValueError(f"FOV names found in the run file were not in tiled (RnCm) format.")
-    else:
-        num_cols = math.isqrt(len(folders))
-        max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)
 
     # make stitched subdir
     os.makedirs(stitched_dir)
@@ -175,7 +173,9 @@ def stitch_images(
                     prefix = "unnamed_tile"
                 # subset the folders_dict for fovs found in the current tile
                 tile_dict = {
-                    fov: folders_dict[fov] for fov in expected_fovs if fov in folders_dict.keys()
+                    fov: tiled_folders_dict[fov]
+                    for fov in expected_fovs
+                    if fov in tiled_folders_dict.keys()
                 }
 
                 # save to individual tile subdirs
@@ -196,7 +196,17 @@ def stitch_images(
                 current_img = stitched.loc["stitched_image", :, :, chan].values / scale
                 image_utils.save_image(fname, current_img)
 
-        else:
+        if tma_folders or not tiled:
+            # save to individual tma subdir
+            if tma_folders:
+                folders = tma_folders
+                stitched_dir = os.path.join(stitched_dir, "TMA")
+                if not os.path.exists(stitched_dir):
+                    os.makedirs(stitched_dir)
+
+            num_cols = math.isqrt(len(folders))
+            max_img_size = get_max_img_size(tiff_out_dir, img_sub_folder, run_dir)
+
             image_data = load_utils.load_imgs_from_tree(
                 tiff_out_dir,
                 img_sub_folder=img_sub_folder,

--- a/tests/image_stitching_test.py
+++ b/tests/image_stitching_test.py
@@ -144,7 +144,7 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
     ]
     fov_num = 4
     if nontiled_fov:
-        fov_num = 5
+        fov_num = 6
     fov_list = [f"fov-{i}-scan-1" for i in range(1, fov_num + 1)]
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -181,14 +181,14 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
             for i, tile in enumerate(tile_names):
                 save_dir = os.path.join(tmpdir, stitched_dir, tile[:-1])
                 assert sorted(io_utils.list_files(save_dir)) == sorted(stitched_tifs)
-                data = load_utils.load_imgs_from_dir(save_dir, files=["Au_stitched.tiff"])
+                tiled_data = load_utils.load_imgs_from_dir(save_dir, files=["Au_stitched.tiff"])
                 if i == 0:
-                    assert data.shape == (1, 20, 30, 1)
+                    assert tiled_data.shape == (1, 20, 30, 1)
                 else:
-                    assert data.shape == (1, 20, 20, 1)
+                    assert tiled_data.shape == (1, 20, 20, 1)
 
                 _, expected_fovs, num_rows, num_cols = expected_tiles[i]
-                # data_trim = data[0, ..., ..., 0].values
+
                 base_data = load_utils.load_tiled_img_data(
                     tmpdir,
                     {fov: folders_dict[fov] for fov in expected_fovs if fov in folders_dict.keys()},
@@ -197,8 +197,15 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
                     single_dir=False,
                     img_sub_folder=subdir,
                 )
-                _tiled_image_check(data, base_data, num_rows, num_cols)
-        # max img size 10 with 4 or 5 acquired fovs
+                _tiled_image_check(tiled_data, base_data, num_rows, num_cols)
+            # check for tma stitched files
+            if nontiled_fov:
+                save_dir = os.path.join(tmpdir, stitched_dir, "TMA")
+                assert sorted(io_utils.list_files(save_dir)) == sorted(stitched_tifs)
+                tma_data = load_utils.load_imgs_from_dir(save_dir, files=["Au_stitched.tiff"])
+                assert tma_data.shape == (1, 20, 10, 1)
+
+        # max img size 10 with 4 or 6 acquired fovs
         else:
             save_dir = os.path.join(tmpdir, stitched_dir)
             assert sorted(io_utils.list_files(save_dir)) == sorted(stitched_tifs)

--- a/tests/image_stitching_test.py
+++ b/tests/image_stitching_test.py
@@ -143,7 +143,11 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
         "CD11c_stitched.tiff",
     ]
     # ignore moly fov in run file
-    fov_list = ["fov-1-scan-1", "fov-2-scan-1", "fov-4-scan-1"]
+    fov_list = (
+        ["fov-1-scan-1", "fov-2-scan-1", "fov-4-scan-1", "fov-5-scan-1", "fov-6-scan-1"]
+        if nontiled_fov
+        else ["fov-1-scan-1", "fov-2-scan-1", "fov-4-scan-1"]
+    )
 
     with tempfile.TemporaryDirectory() as tmpdir:
         run_name = os.path.basename(tmpdir)

--- a/tests/image_stitching_test.py
+++ b/tests/image_stitching_test.py
@@ -142,10 +142,8 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
         "CD8_stitched.tiff",
         "CD11c_stitched.tiff",
     ]
-    fov_num = 4
-    if nontiled_fov:
-        fov_num = 6
-    fov_list = [f"fov-{i}-scan-1" for i in range(1, fov_num + 1)]
+    # ignore moly fov in run file
+    fov_list = ["fov-1-scan-1", "fov-2-scan-1", "fov-4-scan-1"]
 
     with tempfile.TemporaryDirectory() as tmpdir:
         run_name = os.path.basename(tmpdir)
@@ -198,14 +196,14 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
                     img_sub_folder=subdir,
                 )
                 _tiled_image_check(tiled_data, base_data, num_rows, num_cols)
-            # check for tma stitched files
+            # check for 2 tma stitched files
             if nontiled_fov:
                 save_dir = os.path.join(tmpdir, stitched_dir, "TMA")
                 assert sorted(io_utils.list_files(save_dir)) == sorted(stitched_tifs)
                 tma_data = load_utils.load_imgs_from_dir(save_dir, files=["Au_stitched.tiff"])
                 assert tma_data.shape == (1, 20, 10, 1)
 
-        # max img size 10 with 4 or 6 acquired fovs
+        # max img size 10 with 3 or 5 acquired fovs
         else:
             save_dir = os.path.join(tmpdir, stitched_dir)
             assert sorted(io_utils.list_files(save_dir)) == sorted(stitched_tifs)
@@ -213,7 +211,7 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir):
             if nontiled_fov:
                 assert data.shape == (1, 30, 20, 1)
             else:
-                assert data.shape == (1, 20, 20, 1)
+                assert data.shape == (1, 30, 10, 1)
 
             # data_trim = data[0, ..., ..., 0].values
             base_data = load_utils.load_imgs_from_tree(

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -35,7 +35,8 @@ def make_run_file(tmp_dir, prefixes=[], include_nontiled=False):
         f"{prefix2}R2C2": 8,
     }
     if include_nontiled:
-        fov_data["nontiled"] = 8
+        fov_data["nontiled_1"] = 8
+        fov_data["nontiled_2"] = 8
 
     run_data = []
     for i, fov in enumerate(fov_data.keys()):


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

It is now more common for users to create runs comprised of both tiled regions and TMAs. The current stitching notebook ignores any non-tiled images when `tiled_image = True`. We would instead like to create a separate acquisition based stitched image for any FOVs without a RnCm name.

**How did you implement your changes**

After retrieving the list of tiled FOVs from the run file, simply check if there are any image folders that are not included in this list, and if so stitched them and save in their own `"{run_name}_stitched/TMA"` subdirectory. 
Add tests to check for the existence of these outputted images, and check for the correct shape.

**Remaining issues**

N/A
