### PR TITLE
Allow for image specified for flatfield correction to be empty

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -268,7 +268,10 @@ def compensate_image_data(
     all_masses = comp_mat.columns.values.astype("int")
 
     # convert ffc mass into ffc channel names
-    ffc_channels = [panel_info.loc[panel_info.Mass == mass].Target.values[0] for mass in ffc_masses]
+    if ffc_masses is not None:
+        ffc_channels = [panel_info.loc[panel_info.Mass == mass].Target.values[0] for mass in ffc_masses]
+    else:
+        ffc_channels = None
 
     validate_inputs(
         raw_data_dir,
@@ -691,6 +694,7 @@ def generate_rosetta_test_imgs(
     panel,
     current_channel_name="Noodle",
     output_channel_names=None,
+    ffc_masses=[39]
 ):
     """Compensate example FOV images based on given multipliers
     Args:
@@ -701,6 +705,7 @@ def generate_rosetta_test_imgs(
         panel (pd.DataFrame): the panel containing the masses and channel names
         current_channel_name (str): channel being adjusted, default Noodle
         output_channel_names (list): subset of the channels to compensate for, default None is all
+        ffc_masses (list): masses that need to be flat field corrected.
 
     Returns:
         Create subdirs containing rosetta compensated images for each multiplier and stitched imgs
@@ -747,4 +752,5 @@ def generate_rosetta_test_imgs(
             batch_size=1,
             norm_const=1,
             output_masses=output_masses,
+            ffc_masses=ffc_masses
         )

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -3,6 +3,7 @@ import json
 import os
 import random
 import shutil
+import warnings
 
 import natsort as ns
 import numpy as np
@@ -175,6 +176,11 @@ def flat_field_correction(img, gaus_rad=100):
 
     Returns:
         np.ndarray: corrected image"""
+
+    # if image is empty, return empty image
+    if not np.any(img):
+        warnings.warn("Image for flatfield correction is empty")
+        return img
 
     # smooth image
     img_smooth = gaussian_filter(img, sigma=gaus_rad)

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -269,7 +269,9 @@ def compensate_image_data(
 
     # convert ffc mass into ffc channel names
     if ffc_masses is not None:
-        ffc_channels = [panel_info.loc[panel_info.Mass == mass].Target.values[0] for mass in ffc_masses]
+        ffc_channels = [
+            panel_info.loc[panel_info.Mass == mass].Target.values[0] for mass in ffc_masses
+        ]
     else:
         ffc_channels = None
 
@@ -694,7 +696,7 @@ def generate_rosetta_test_imgs(
     panel,
     current_channel_name="Noodle",
     output_channel_names=None,
-    ffc_masses=[39]
+    ffc_masses=[39],
 ):
     """Compensate example FOV images based on given multipliers
     Args:
@@ -752,5 +754,5 @@ def generate_rosetta_test_imgs(
             batch_size=1,
             norm_const=1,
             output_masses=output_masses,
-            ffc_masses=ffc_masses
+            ffc_masses=ffc_masses,
         )

--- a/templates/4a_compensate_image_data.ipynb
+++ b/templates/4a_compensate_image_data.ipynb
@@ -188,7 +188,7 @@
     "# create sub-folder to hold images and files from this set of multipliers\n",
     "folder_path = os.path.join(rosetta_testing_dir, cohort_name, folder_name)\n",
     "if os.path.exists(folder_path):\n",
-    "    raise ValueError('This folder {} already exists, please' \n",
+    "    raise ValueError('This folder {} already exists, please ' \n",
     "                     'pick a new name for each set of parameters'.format(folder_name))\n",
     "else:\n",
     "    os.makedirs(folder_path)\n",

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -655,7 +655,7 @@ def create_rosetta_comp_structure(
     batch_size=1,
     gaus_rad=1,
     norm_const=200,
-    ffc_channels=["chan_39"],
+    ffc_masses=[39],
     correct_streaks=False,
     streak_chan="Noodle",
 ):

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -227,7 +227,7 @@ def test_flat_field_correction():
     assert not np.array_equal(corrected_img, input_img)
 
     # test empty image
-    with pytest.warns(UserWarning, match=''):
+    with pytest.warns(UserWarning, match='Image for flatfield correction is empty'):
         input_img = np.zeros((10, 10))
         corrected_img = rosetta.flat_field_correction(img=input_img)
 

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -226,6 +226,13 @@ def test_flat_field_correction():
     assert corrected_img.shape == input_img.shape
     assert not np.array_equal(corrected_img, input_img)
 
+    # test empty image
+    with pytest.warns(UserWarning, match=''):
+        input_img = np.zeros((10, 10))
+        corrected_img = rosetta.flat_field_correction(img=input_img)
+
+        assert not np.any(input_img)
+
 
 def test_get_masses_from_channel_names():
     targets = ["chan1", "chan2", "chan3"]

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -227,7 +227,7 @@ def test_flat_field_correction():
     assert not np.array_equal(corrected_img, input_img)
 
     # test empty image
-    with pytest.warns(UserWarning, match='Image for flatfield correction is empty'):
+    with pytest.warns(UserWarning, match="Image for flatfield correction is empty"):
         input_img = np.zeros((10, 10))
         corrected_img = rosetta.flat_field_correction(img=input_img)
 

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -231,7 +231,7 @@ def test_flat_field_correction():
         input_img = np.zeros((10, 10))
         corrected_img = rosetta.flat_field_correction(img=input_img)
 
-        assert not np.any(input_img)
+        assert not np.any(corrected_img)
 
 
 def test_get_masses_from_channel_names():
@@ -253,10 +253,11 @@ def test_get_masses_from_channel_names():
 @parametrize("input_masses", [None, [25, 50, 101], [25, 50]])
 @parametrize("gaus_rad", [0, 1, 2])
 @parametrize("save_format", ["raw", "rescaled", "both"])
+@parametrize("ffc_masses", [None, [50]])
 @parametrize_with_cases("panel_info", cases=test_cases.CompensateImageDataPanel)
 @parametrize_with_cases("comp_mat", cases=test_cases.CompensateImageDataMat)
 def test_compensate_image_data(
-    output_masses, input_masses, gaus_rad, save_format, panel_info, comp_mat
+    output_masses, input_masses, gaus_rad, save_format, panel_info, comp_mat, ffc_masses
 ):
     with tempfile.TemporaryDirectory() as top_level_dir:
         data_dir = os.path.join(top_level_dir, "data_dir")
@@ -286,7 +287,7 @@ def test_compensate_image_data(
             output_masses=output_masses,
             save_format=save_format,
             gaus_rad=gaus_rad,
-            ffc_masses=[50],
+            ffc_masses=ffc_masses,
             correct_streaks=True,
             streak_chan="chan1",
         )
@@ -760,3 +761,9 @@ def test_generate_rosetta_test_imgs(mocker):
                 assert os.path.exists(
                     os.path.join(temp_dir, f"Noodle_Au_commercial_rosetta_matrix_v1_mult_{i}.csv")
                 )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # test if ffc_masses is None
+            rosetta.generate_rosetta_test_imgs(
+                rosetta_mat_path, temp_img_dir, mults, temp_dir, panel, ffc_masses=None
+            )


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Handle the case where the image for flatfield correction is empty, and allow for the user to specify no images for flatfield correction. And added a missing space in the jupyter notebook.

**How did you implement your changes**

1. In the flatfield correction function, return an empty array if the input array is all zeros.
2. Allow the user to specify "None" for flatfield correction masses.

Closes #299 
**Remaining issues**

None
