### PR TITLE
Fix rescale_raw_images error

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -677,14 +677,16 @@ def rescale_raw_imgs(img_out_dir, scale=200):
         fov_dir = os.path.join(img_out_dir, fov)
         # create subdirectory for the new images
         sub_dir = os.path.join(fov_dir, "rescaled")
-        os.makedirs(sub_dir)
+        if not os.path.exists(sub_dir):
+            os.makedirs(sub_dir)
         chans = io_utils.list_files(fov_dir)
         # rescale each channel image
         for chan in chans:
-            img = io.imread(os.path.join(fov_dir, chan))
-            img = (img / scale).astype("float32")
             fname = os.path.join(sub_dir, chan)
-            image_utils.save_image(fname, img)
+            if not os.path.exists(fname):
+                img = io.imread(os.path.join(fov_dir, chan))
+                img = (img / scale).astype("float32")
+                image_utils.save_image(fname, img)
 
 
 def generate_rosetta_test_imgs(

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import tempfile
+import time
 from pathlib import Path
 
 import numpy as np
@@ -639,9 +640,16 @@ def test_rescale_raw_imgs():
 
         # test successful rescale of data
         rescaled_img_data = load_utils.load_imgs_from_tree(temp_dir, "rescaled")
+        create_time = Path(os.path.join(temp_dir, fovs[0], "rescaled")).stat().st_ctime
         assert rescaled_img_data.all() == (img_data / 200).all()
 
         assert rescaled_img_data.dtype == "float32"
+
+        # re-run function and check the files are not re-written
+        time.sleep(3)
+        rosetta.rescale_raw_imgs(temp_dir)
+        modify_time = Path(os.path.join(temp_dir, fovs[0], "rescaled")).stat().st_mtime
+        assert np.isclose(modify_time, create_time)
 
 
 def create_rosetta_comp_structure(


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #310. If the cell in the rosetta notebook containing `rosetta.rescale_raw_images()` is run more than once, it will give an error messages that is confusing for the user. We instead want to simply skip any images that have already been rescaled and saved the the subfolder.

**How did you implement your changes**

1. Only create the rescaled subdir if it doesn't exist. 
2. Check for existing channel images in the directory before repeating the process of loading in, scaling, and saving all the images.
3. Update the tests to check the files are not being overwritten when the function is called again.

**Remaining issues**

N/A