### PR TITLE
Ensure watcher can wait on run folder to appear

### DIFF
--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -560,7 +560,7 @@ def start_watcher(
             "before trying again."
         )
 
-    # allow the watcher to
+    # allow the watcher to poll the run folder until it appears or times out
     run_folder_wait_time = 0
     while not os.path.exists(run_folder) and run_folder_wait_time < run_folder_timeout:
         time.sleep(run_folder_timeout / 10)

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -554,7 +554,7 @@ def start_watcher(
 
     if run_folder_wait == run_folder_timeout:
         raise FileNotFoundError(
-            f"run_folder {run_folder} does not exist. First double check that the data doesn't "
+            f"Timed out waiting for {run_folder}. First double check that the data doesn't "
             "already exist in D:\\\\Data (sometimes, the CACs will change capitalization or add "
             "extra characters to the run name). If that isn't the case, then wait 15-30 minutes "
             "before trying again."

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -546,6 +546,12 @@ def start_watcher(
         zero_size_timeout (int):
             number of seconds to wait for non-zero file size
     """
+    confirm = input(
+        f"Move forward with specified run folder {run_folder}? Double check spelling and "
+        "capitalization, sometimes the CACs will add additional characters or add "
+        "weird casing changes"
+    )
+
     # allow the watcher to
     run_folder_wait_time = 0
     while not os.path.exists(run_folder) and run_folder_wait_time < run_folder_timeout:

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -547,12 +547,12 @@ def start_watcher(
             number of seconds to wait for non-zero file size
     """
     # allow the watcher to
-    run_folder_wait = 0
-    while not os.path.exists(run_folder) and run_folder_wait < run_folder_timeout:
+    run_folder_wait_time = 0
+    while not os.path.exists(run_folder) and run_folder_wait_time < run_folder_timeout:
         time.sleep(run_folder_timeout / 10)
-        run_folder_wait += run_folder_timeout / 10
+        run_folder_wait_time += run_folder_timeout / 10
 
-    if run_folder_wait == run_folder_timeout:
+    if run_folder_wait_time == run_folder_timeout:
         raise FileNotFoundError(
             f"Timed out waiting for {run_folder}. First double check that the data doesn't "
             "already exist in D:\\\\Data (sometimes, the CACs will change capitalization or add "

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -553,8 +553,8 @@ def start_watcher(
     # warn the user to explicitly confirm the run folder
     if not os.path.exists(run_folder):
         warnings.warn(
-            f"Waiting for D:\\\\Data\\{run_folder}. Please first double check that your run data "
-            "doesn't already exist under a slightly different name in D:\\\\Data. "
+            f"Waiting for {run_folder}. Please first double check that your run data "
+            "doesn't already exist under a slightly different name in D:\\Data. "
             "Sometimes, the CACs change capitalization or add extra characters to the run folder. "
             "If this happens, stop the watcher and update the run_name variable in the notebook "
             "before trying again."
@@ -569,7 +569,7 @@ def start_watcher(
     if run_folder_wait_time == run_folder_timeout:
         raise FileNotFoundError(
             f"Timed out waiting for {run_folder}. Make sure the run_name variable in the notebook "
-            "matches up with the run folder name in D:\\\\Data, or try again a few minutes later "
+            "matches up with the run folder name in D:\\Data, or try again a few minutes later "
             "if the run folder still hasn't shown up."
         )
 

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -550,7 +550,7 @@ def start_watcher(
         zero_size_timeout (int):
             number of seconds to wait for non-zero file size
     """
-    # warn the user to explicitly confirm the run folder
+    # if the run folder specified isn't already there, ask the user to explicitly confirm the name
     if not os.path.exists(run_folder):
         warnings.warn(
             f"Waiting for {run_folder}. Please first double check that your run data "

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -521,7 +521,7 @@ def start_watcher(
     fov_callback: Callable[[str, str], None],
     run_callback: Callable[[None], None],
     intermediate_callback: Callable[[str, str], None] = None,
-    run_folder_timeout: int = 2700,
+    run_folder_timeout: int = 5400,
     completion_check_time: int = 30,
     zero_size_timeout: int = 7800,
 ):

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -45,7 +45,9 @@ class RunStructure:
 
         # find run .json and get parameters
         run_name = Path(run_folder).parts[-1]
-        run_metadata = read_json_file(os.path.join(run_folder, f"{run_name}.json"))
+        run_metadata = read_json_file(
+            os.path.join(run_folder, f"{run_name}.json"), encoding="utf-8"
+        )
 
         # parse run_metadata and populate expected structure
         for fov in run_metadata.get("fovs", ()):

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -546,10 +546,13 @@ def start_watcher(
         zero_size_timeout (int):
             number of seconds to wait for non-zero file size
     """
-    confirm = input(
-        f"Move forward with specified run folder {run_folder}? Double check spelling and "
-        "capitalization, sometimes the CACs will add additional characters or add "
-        "weird casing changes"
+    # warn the user to explicitly confirm the run folder
+    warnings.warn(
+        f"Listening at D:\\\\Data\\{run_folder}. Please first double check that your run data "
+        "doesn't already exist under a slightly different name in D:\\\\Data. "
+        "Sometimes, the CACs will change capitalization or add extra characters to the run folder. "
+        f"If this is the case, stop the watcher and update {run_name} in the notebook "
+        "before trying again."
     )
 
     # allow the watcher to
@@ -560,10 +563,9 @@ def start_watcher(
 
     if run_folder_wait_time == run_folder_timeout:
         raise FileNotFoundError(
-            f"Timed out waiting for {run_folder}. First double check that the data doesn't "
-            "already exist in D:\\\\Data (sometimes, the CACs will change capitalization or add "
-            "extra characters to the run name). If that isn't the case, then wait 15-30 minutes "
-            "before trying again."
+            f"Timed out waiting for {run_folder}. Make sure {run_name} in the notebook matches up "
+            "with the run folder name in D:\\\\Data, or try again later if the run folder still "
+            "hasn't shown up."
         )
 
     observer = Observer()

--- a/src/toffy/fov_watcher.py
+++ b/src/toffy/fov_watcher.py
@@ -551,13 +551,14 @@ def start_watcher(
             number of seconds to wait for non-zero file size
     """
     # warn the user to explicitly confirm the run folder
-    warnings.warn(
-        f"Listening at D:\\\\Data\\{run_folder}. Please first double check that your run data "
-        "doesn't already exist under a slightly different name in D:\\\\Data. "
-        "Sometimes, the CACs will change capitalization or add extra characters to the run folder. "
-        "If this is the case, stop the watcher and update the run_name variable in the notebook "
-        "before trying again."
-    )
+    if not os.path.exists(run_folder):
+        warnings.warn(
+            f"Waiting for D:\\\\Data\\{run_folder}. Please first double check that your run data "
+            "doesn't already exist under a slightly different name in D:\\\\Data. "
+            "Sometimes, the CACs change capitalization or add extra characters to the run folder. "
+            "If this happens, stop the watcher and update the run_name variable in the notebook "
+            "before trying again."
+        )
 
     # allow the watcher to
     run_folder_wait_time = 0

--- a/tests/fov_watcher_test.py
+++ b/tests/fov_watcher_test.py
@@ -140,6 +140,7 @@ def test_watcher_run_timeout(lag_time):
         run_folder_timeout = 3
 
         run_folder = os.path.join(tmpdir, "sample_run_folder")
+        os.mkdir(run_folder)
         log_folder = os.path.join(tmpdir, "sample_log_folder")
         run_cbs = ["plot_qc_metrics", "plot_mph_metrics", "image_stitching"]
         fov_cbs = ["extract_tiffs", "generate_pulse_heights"]
@@ -187,7 +188,9 @@ def test_watcher_run_timeout(lag_time):
 @pytest.mark.parametrize("add_blank", [False, True])
 @pytest.mark.parametrize("temp_bin", [False, True])
 @pytest.mark.parametrize("watcher_start_lag", [4, 8, 12])
-@parametrize_with_cases("run_cbs, int_cbs, fov_cbs, kwargs, validators", cases=WatcherCases)
+@parametrize_with_cases(
+    "run_cbs, int_cbs, fov_cbs, kwargs, validators, folder_lag_time", cases=WatcherCases
+)
 def test_watcher(
     mock_viz_qc,
     mock_viz_mph,
@@ -196,6 +199,7 @@ def test_watcher(
     fov_cbs,
     kwargs,
     validators,
+    folder_lag_time,
     add_blank,
     temp_bin,
     watcher_start_lag,

--- a/tests/fov_watcher_test.py
+++ b/tests/fov_watcher_test.py
@@ -134,6 +134,7 @@ def _slow_create_run_folder(run_folder_path: str, lag_time: int):
     write_json_file(
         json_path=os.path.join(run_folder_path, "test_run.json"),
         json_object=COMBINED_RUN_JSON_SPOOF,
+        encoding="utf-8",
     )
 
 
@@ -269,6 +270,7 @@ def test_watcher(
             write_json_file(
                 json_path=os.path.join(run_data, "test_run.json"),
                 json_object=COMBINED_RUN_JSON_SPOOF,
+                encoding="utf-8",
             )
 
             # if existing_data set to True, test case where a FOV has already been extracted

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -521,6 +521,7 @@ class WatcherCases:
             ["extract_tiffs", "generate_pulse_heights"],
             kwargs,
             validators,
+            0,
         )
 
     @parametrize(intensity=(False, True))
@@ -530,4 +531,10 @@ class WatcherCases:
         ics = rcs[:2]
         rcs = rcs[2:]
 
-        return (rcs, ics, fcs, kwargs, validators)
+        return (rcs, ics, fcs, kwargs, validators, 0)
+
+    @parametrize(folder_lag_time=(0, 2, 6))
+    def case_folder_lag(self, folder_lag_time):
+        rcs, ics, fcs, kwargs, validators = self.case_default(False, False)
+
+        return (rcs, ics, fc, kwargs, validators, folder_lag_time)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -563,7 +563,6 @@ class WatcherCases:
             ["extract_tiffs", "generate_pulse_heights"],
             kwargs,
             validators,
-            0,
             1,
             (False, None),
         )
@@ -571,18 +570,18 @@ class WatcherCases:
     @parametrize(intensity=(False, True))
     @parametrize(replace=(False, True))
     def case_inter_callback(self, intensity, replace):
-        rcs, _, fcs, kwargs, validators, fl, wsl, ed = self.case_default(intensity, replace)
+        rcs, _, fcs, kwargs, validators, wsl, ed = self.case_default(intensity, replace)
         ics = rcs[:2]
         rcs = rcs[2:]
 
-        return (rcs, ics, fcs, kwargs, validators, fl, wsl, ed)
+        return (rcs, ics, fcs, kwargs, validators, wsl, ed)
 
     @parametrize(watcher_start_lag=(4, 8, 12))
     def case_watcher_lag(self, watcher_start_lag):
-        rcs, ics, fcs, kwargs, validators, fl, _, ed = self.case_default(True, True)
-        return (rcs, ics, fcs, kwargs, validators, fl, watcher_start_lag, ed)
+        rcs, ics, fcs, kwargs, validators, _, ed = self.case_default(True, True)
+        return (rcs, ics, fcs, kwargs, validators, watcher_start_lag, ed)
 
     @parametrize(existing_data=((True, "Full"), (True, "Partial"), (False, None)))
     def case_existing_data(self, existing_data):
-        rcs, ics, fcs, kwargs, validators, fl, wsl, _ = self.case_default(False, False)
-        return (rcs, ics, fcs, kwargs, validators, fl, wsl, existing_data)
+        rcs, ics, fcs, kwargs, validators, wsl, _ = self.case_default(False, False)
+        return (rcs, ics, fcs, kwargs, validators, wsl, existing_data)


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #377. The watcher is not currently designed to run until the run folder appears. This is problematic because this doesn't happen until about 15-30 minutes into the start of a run. The user needs to be able to spin up the watcher immediately after the run starts, otherwise it causes a significant inconvenience.

**How did you implement your changes**

`fov_watcher.start_watcher` will now take a new argument, `run_folder_timeout`, that controls how long the watcher waits for the run folder to appear. This allows implementation of timing logic similar to the timeout logic for waiting on `.bin` and `.json` files. The watcher will wait until either the run folder appears (in which case it listens for files inside run folder) or `run_folder_timeout` is reached (in which case it errors out with an informative message to the user).

Occasionally, what happens is the CACs will change the casing and/or add extraneous characters (notably `"T"` as a timestamp marker) to run names. If the run folder specified by the user hasn't already written to the CAC, warn the user to double check the run folder doesn't already exist in the `D:\\Data` folder under a slightly different name.

**Remaining issues**

Should we instead include the warning in a cell prior?