### PR TITLE
Ensure runs below fovs_per_num threshold get skipped during Rosetta t…

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -634,18 +634,30 @@ def copy_image_files(
         # check number of fovs in each run
         if len(fovs_in_run) < fovs_per_run:
             small_runs.append(run)
+
+    run_names_process = run_names[:]
     if len(small_runs) > 0:
-        raise ValueError(
-            f"The run folders {small_runs} do not contain the minimum amount of FOVs "
-            f"({fovs_per_run}) defined by the fovs_per_run given."
+        # edge case if none of the runs in run_names have length equal to fovs_per_run
+        if len(small_runs) == len(run_names_process):
+            raise ValueError(
+                f"None of the runs specified contain the minimum amount of FOVs ({fovs_per_run}) "
+                "defined by the fovs_per_run given"
+            )
+
+        # warn user that runs below fovs_per_run threshold will be skipped
+        warnings.warn(
+            "The following runs will be skipped because they do not contain the minimum amount "
+            f"of FOVs ({fovs_per_run}) defined by the fovs_per_run given: {small_runs}."
         )
+
+        run_names_process = list(set(run_names_process).difference(small_runs))
 
     # make rosetta testing dir and extracted images subdir
     cohort_rosetta_dir = os.path.join(rosetta_testing_dir, cohort_name)
     os.makedirs(os.path.join(cohort_rosetta_dir, "extracted_images"))
 
     # randomly choose fovs from a run and copy them to the img subdir in rosetta testing dir
-    for i, run in enumerate(ns.natsorted(run_names)):
+    for i, run in enumerate(ns.natsorted(run_names_process)):
         run_path = os.path.join(extracted_imgs_dir, run)
 
         fovs_in_run = io_utils.list_folders(run_path, substrs="fov")

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -301,7 +301,7 @@ def compensate_image_data(
 
     # loop over each set of FOVs in the batch
     for i in range(0, len(fovs), batch_size):
-        print("Processing image {}".format(i + 1))
+        print(f"Processing FOV {fovs[i]}")
 
         # load batch of fovs
         batch_fovs = fovs[i : i + batch_size]

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -301,7 +301,7 @@ def compensate_image_data(
 
     # loop over each set of FOVs in the batch
     for i in range(0, len(fovs), batch_size):
-        print(f"Processing FOV {fovs[i]}")
+        print(f"Processing {fovs[i]}")
 
         # load batch of fovs
         batch_fovs = fovs[i : i + batch_size]


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #309. Closes #340. During Rosetta test set generation, sometimes the user will specify a `fovs_per_num` threshold that a few runs don't meet. This will cause the whole process to error out when in reality its fine that those runs don't make it in. If there are a lot of runs (sometimes over 100), it is cumbersome for the user to pick out which ones need to be removed.

To make things simple, just ensure that any runs that don't meet the `fovs_per_num` threshold in `copy_image_files`. Only if none of them do should we error out.

**How did you implement your changes**

Modify `copy_image_files` so that only a `warnings.warn` is thrown if some FOVs get skipped over. However, do keep the `ValueError` in case no runs get copied over.

**Remaining issues**

This doesn't exactly solve the issue of what happens if the user only ends up with a few valid runs out of several hundred due to a `fovs_per_run` that was unusually high. We might want to specify a percentage threshold for erroring out to account for this (ex. if fewer than 50% of `run_names` meet the threshold, error out and let the user know that the Rosetta results will not be indicative of the desired test set).