### PR TITLE
QC Metrics - Save Longitudinal Transformed Metrics

### DIFF
--- a/src/toffy/qc_comp.py
+++ b/src/toffy/qc_comp.py
@@ -909,7 +909,7 @@ class QCControlMetrics:
             ) from e
 
         # Apply a log2 transformation to the mean normalized data.
-        log2_norm_df: pd.DataFrame = df.pivot_table(
+        log2_norm_df: pd.DataFrame = df.pivot(
             index="channel", columns="fov", values=qc_metric
         ).transform(func=lambda row: np.log2(row / row.mean()), axis=1)
 
@@ -924,6 +924,10 @@ class QCControlMetrics:
             objs=[log2_norm_df, mean_log2_norm_df]
         ).sort_values(by="mean", axis=1, inplace=False)
 
+        transformed_df.rename_axis("channel", axis=0, inplace=True)
+        transformed_df.rename_axis("fov", axis=1, inplace=True)
+
+        # Save the pivoted dataframe to a csv
         if to_csv:
             qc_suffix: str = self.qc_suffixes[self.qc_cols.index(qc_metric)]
             transformed_df.to_csv(
@@ -931,7 +935,7 @@ class QCControlMetrics:
                     self.metrics_dir,
                     f"{control_sample_name}_transformed_{qc_suffix}.csv",
                 ),
-                index=False,
+                index=True,
             )
 
         return transformed_df

--- a/src/toffy/qc_comp.py
+++ b/src/toffy/qc_comp.py
@@ -876,7 +876,7 @@ class QCControlMetrics:
             )
 
     def transformed_control_effects_data(
-        self, control_sample_name: str, qc_metric: str
+        self, control_sample_name: str, qc_metric: str, to_csv: bool = False
     ) -> pd.DataFrame:
         """
         Creates a transformed DataFrame for the Longitudinal Control effects data, normalizing by the mean,
@@ -885,6 +885,7 @@ class QCControlMetrics:
         Args:
             control_sample_name (str): A control sample to tranform the longitudinal control effects for.
             qc_metric (str): The metric to transform.
+            to_csv (bool, optional): Whether to save the transformed data to a csv. Defaults to False.
 
         Returns:
             pd.DataFrame: The transformed QC Longitudinal Control data.
@@ -908,7 +909,7 @@ class QCControlMetrics:
             ) from e
 
         # Apply a log2 transformation to the mean normalized data.
-        log2_norm_df: pd.DataFrame = df.pivot(
+        log2_norm_df: pd.DataFrame = df.pivot_table(
             index="channel", columns="fov", values=qc_metric
         ).transform(func=lambda row: np.log2(row / row.mean()), axis=1)
 
@@ -922,5 +923,15 @@ class QCControlMetrics:
         transformed_df: pd.DataFrame = pd.concat(
             objs=[log2_norm_df, mean_log2_norm_df]
         ).sort_values(by="mean", axis=1, inplace=False)
+
+        if to_csv:
+            qc_suffix: str = self.qc_suffixes[self.qc_cols.index(qc_metric)]
+            transformed_df.to_csv(
+                os.path.join(
+                    self.metrics_dir,
+                    f"{control_sample_name}_transformed_{qc_suffix}.csv",
+                ),
+                index=False,
+            )
 
         return transformed_df

--- a/src/toffy/qc_metrics_plots.py
+++ b/src/toffy/qc_metrics_plots.py
@@ -271,6 +271,7 @@ def longitudinal_control_heatmap(
                     qc_control.metrics_dir, f"{control_sample_name}_transformed_{qc_suffix}.csv"
                 )
             )
+            t_df.rename_axis("fov", axis=1, inplace=True)
         # If it doesn't exist, transform the data and save it.
         except FileNotFoundError:
             t_df: pd.DataFrame = qc_control.transformed_control_effects_data(
@@ -288,6 +289,13 @@ def longitudinal_control_heatmap(
 
         fig.suptitle(f"{control_sample_name} - QC: {qc_col}")
 
+        # Annontation kwargs
+        annotation_kws = {
+            "horizontalalignment": "center",
+            "verticalalignment": "center",
+            "fontsize": 8,
+        }
+
         # Heatmap
         ax_heatmap: Axes = fig.add_subplot(gs[0, 0])
 
@@ -298,11 +306,7 @@ def longitudinal_control_heatmap(
             linecolor="black",
             cbar_kws={"shrink": 0.5},
             annot=True,
-            annot_kws={
-                "horizontalalignment": "center",
-                "verticalalignment": "center",
-                "fontsize": 8,
-            },
+            annot_kws=annotation_kws,
             xticklabels=False,
             norm=_norm,
             cmap=_cmap,
@@ -328,6 +332,7 @@ def longitudinal_control_heatmap(
             linewidths=1,
             linecolor="black",
             annot=True,
+            annot_kws=annotation_kws,
             fmt=".2f",
             cmap=ListedColormap(["white"]),
             cbar=False,

--- a/tests/qc_comp_test.py
+++ b/tests/qc_comp_test.py
@@ -704,7 +704,8 @@ class TestQCControlMetrics:
         assert os.path.exists(transformed_df_path)
         # Assert that the transformed csv is the same as the one returned by the function
 
-        saved_transformed_df = pd.read_csv(transformed_df_path)
+        saved_transformed_df = pd.read_csv(transformed_df_path, index_col=["channel"])
+        saved_transformed_df.rename_axis("fov", axis=1, inplace=True)
 
         pd.testing.assert_frame_equal(left=transformed_df, right=saved_transformed_df)
 

--- a/tests/qc_comp_test.py
+++ b/tests/qc_comp_test.py
@@ -611,17 +611,17 @@ class TestQCControlMetrics:
     def _setup(self, cohort_data: BatchEffectMetricData) -> None:
         self.cohort_data: BatchEffectMetricData = cohort_data
 
-        self.qc_batch_effect = qc_comp.QCControlMetrics(
+        self.qc_control_metrics = qc_comp.QCControlMetrics(
             qc_metrics=settings.QC_COLUMNS,
             cohort_path=self.cohort_data.cohort_img_dir,
             metrics_dir=self.cohort_data.cohort_metrics_dir,
         )
 
     def test__post_init__(self) -> None:
-        assert self.qc_batch_effect.qc_cols == settings.QC_COLUMNS
-        assert self.qc_batch_effect.qc_suffixes == settings.QC_SUFFIXES
+        assert self.qc_control_metrics.qc_cols == settings.QC_COLUMNS
+        assert self.qc_control_metrics.qc_suffixes == settings.QC_SUFFIXES
 
-        assert self.qc_batch_effect.longitudinal_control_metrics == {}
+        assert self.qc_control_metrics.longitudinal_control_metrics == {}
 
     @parametrize(
         "_control_sample_name,_channel_include,_channel_exclude",
@@ -639,7 +639,7 @@ class TestQCControlMetrics:
         _channel_include,
         _channel_exclude,
     ) -> None:
-        self.qc_batch_effect.compute_control_qc_metrics(
+        self.qc_control_metrics.compute_control_qc_metrics(
             control_sample_name=_control_sample_name,
             fovs=self.cohort_data.fovs,
             channel_exclude=_channel_exclude,
@@ -648,12 +648,12 @@ class TestQCControlMetrics:
 
         for qc_suffix in settings.QC_SUFFIXES:
             assert os.path.exists(
-                self.qc_batch_effect.metrics_dir
+                self.qc_control_metrics.metrics_dir
                 / f"{_control_sample_name}_combined_{qc_suffix}.csv"
             )
 
             qc_df = pd.read_csv(
-                self.qc_batch_effect.metrics_dir
+                self.qc_control_metrics.metrics_dir
                 / f"{_control_sample_name}_combined_{qc_suffix}.csv"
             )
             assert set(qc_df["channel"]).isdisjoint(set(settings.QC_CHANNEL_IGNORE))
@@ -681,17 +681,32 @@ class TestQCControlMetrics:
         ],
     )
     def test_transformed_control_effects_data(self, _control_sample_name, _metric) -> None:
-        self.qc_batch_effect.compute_control_qc_metrics(
+        self.qc_control_metrics.compute_control_qc_metrics(
             control_sample_name=_control_sample_name,
             fovs=self.cohort_data.fovs,
             channel_exclude=None,
             channel_include=None,
         )
 
-        transformed_df = self.qc_batch_effect.transformed_control_effects_data(
-            control_sample_name=_control_sample_name, qc_metric=_metric
+        transformed_df = self.qc_control_metrics.transformed_control_effects_data(
+            control_sample_name=_control_sample_name, qc_metric=_metric, to_csv=True
         )
-        # self.cohort_data.qc_df
+
+        # Asser that the transformed control effects file is created.
+        _qc_suffix = self.qc_control_metrics.qc_suffixes[
+            self.qc_control_metrics.qc_cols.index(_metric)
+        ]
+        transformed_df_path = os.path.join(
+            self.qc_control_metrics.metrics_dir,
+            f"{_control_sample_name}_transformed_{_qc_suffix}.csv",
+        )
+
+        assert os.path.exists(transformed_df_path)
+        # Assert that the transformed csv is the same as the one returned by the function
+
+        saved_transformed_df = pd.read_csv(transformed_df_path)
+
+        pd.testing.assert_frame_equal(left=transformed_df, right=saved_transformed_df)
 
         # All FOVs exist
         assert set(transformed_df.axes[1]) == set(self.cohort_data.qc_df["fov"])


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Saves the transformed DataFrame created by `transformed_control_effects_data`. 

**How did you implement your changes**

Added a `to_csv` parameter to `transformed_control_effects_data` along with `save_lc_df` in `qc_metrics_plots.longitudinal_control_heatmap`.

**Remaining issues**

N/A.