### PR TITLE
Ensure pulse heights file is named with `_` not `-`

### DIFF
--- a/src/toffy/watcher_callbacks.py
+++ b/src/toffy/watcher_callbacks.py
@@ -301,7 +301,7 @@ class FovCallbacks:
         if not os.path.exists(pulse_out_dir):
             os.makedirs(pulse_out_dir)
 
-        pulse_height_file = os.path.join(pulse_out_dir, f"{self.point_name}-pulse_heights.csv")
+        pulse_height_file = os.path.join(pulse_out_dir, f"{self.point_name}_pulse_heights.csv")
         if os.path.exists(pulse_height_file) and not self.overwrite:
             warnings.warn(f"Pulse heights per mass already extracted for FOV {self.point_name}")
             return

--- a/tests/fov_watcher_test.py
+++ b/tests/fov_watcher_test.py
@@ -303,7 +303,7 @@ def test_watcher(
                 df_ph = pd.DataFrame(np.random.rand(10, 3), columns=["mass", "fov", "pulse_height"])
                 df_ph["fov"] = "fov-2-scan-1"
                 df_ph.to_csv(
-                    os.path.join(pulse_out_dir, "fov-2-scan-1-pulse_heights.csv"), index=False
+                    os.path.join(pulse_out_dir, "fov-2-scan-1_pulse_heights.csv"), index=False
                 )
 
             # `_slow_copy_sample_tissue_data` mimics the instrument computer uploading data to the


### PR DESCRIPTION
**What is the purpose of this PR?**

Corrects the way `watcher_callbacks.py` looks for `_pulse_heights.csv` files.

**How did you implement your changes**

Previously, these pulse height files were specified as `-pulse_heights.csv`. They should be `_pulse_heights.csv` instead.

**Remaining issues**

The MPH pulse files actually do use `-mph_pulse.csv` as a suffix, which is where the confusion arose from. We should think about standardizing this naming scheme.