### PR TITLE
Remove hanging `extracted_imgs_dir` reference in Rosetta notebook

### DIFF
--- a/templates/4a_compensate_image_data.ipynb
+++ b/templates/4a_compensate_image_data.ipynb
@@ -88,7 +88,6 @@
     "cohort_name = '20220101_new_cohort'\n",
     "run_names = ['20220101_TMA1', '20220102_TMA2']\n",
     "panel_path = 'C:\\\\Users\\\\Customer.ION\\\\Documents\\\\panel_files\\\\my_cool_panel.csv'\n",
-    "extracted_imgs_dir = 'D:\\\\Extracted_Images'\n",
     "\n",
     "# if you would like to process all of the run folders in the image dir instead of just the runs tested, you can use the below line\n",
     "# run_names = list_folders(extracted_imgs_dir)"


### PR DESCRIPTION
**What is the purpose of this PR?**

Duplicate variable definitions are ugly.

**How did you implement your changes**

Nuke duplicate variable definitions.