### PR TITLE
Check for partially generated fovs

### DIFF
--- a/src/toffy/bin_extraction.py
+++ b/src/toffy/bin_extraction.py
@@ -1,10 +1,14 @@
+import os
+import re
 import warnings
 
 import natsort as ns
-from alpineer import io_utils
+import numpy as np
+import pandas as pd
+from alpineer import io_utils, load_utils
 from mibi_bin_tools import bin_files
 
-from toffy.json_utils import check_for_empty_files, list_moly_fovs
+from toffy.json_utils import check_for_empty_files, list_moly_fovs, read_json_file
 
 
 def extract_missing_fovs(
@@ -71,3 +75,52 @@ def extract_missing_fovs(
         print("Extraction completed!")
     else:
         warnings.warn(f"No viable bin files were found in {bin_file_dir}", Warning)
+
+
+def incomplete_fov_check(bin_file_dir, extraction_dir, num_rows=10, num_channels=5):
+    """Read in the supplied number tiff files for each FOV to check for incomplete images
+    Args:
+        bin_file_dir (str): directory containing the run json file
+        extraction_dir (str): directory containing the extracted tifs
+        num_rows (int): number of bottom rows of the images to check for zero values
+        num_channels (int): number of channel images to check per FOV
+
+    Raises:
+        Warning if any FOVs have only partially generated images
+    """
+
+    io_utils.validate_paths([bin_file_dir, extraction_dir])
+
+    # read in json file to get custom fov names
+    run_name = os.path.basename(bin_file_dir)
+    run_file_path = os.path.join(bin_file_dir, run_name + ".json")
+    run_metadata = read_json_file(run_file_path, encoding="utf-8")
+
+    # read in run file
+    fovs = io_utils.list_folders(extraction_dir, "fov")
+    channels = io_utils.list_files(os.path.join(extraction_dir, fovs[0]), ".tiff")
+    channels_subset = channels[:num_channels]
+
+    incomplete_fovs = {}
+    for fov in fovs:
+        # load in channel images
+        img_data = load_utils.load_imgs_from_tree(
+            extraction_dir, fovs=[fov], channels=channels_subset
+        )
+        row_index = img_data.shape[1] - num_rows
+        img_bottoms = img_data[0, row_index:, :, :]
+
+        # check percentage of non-zero pixels in the bottom of the image
+        total_pixels = img_data.shape[1] * num_rows * num_channels
+        if np.count_nonzero(img_bottoms) / total_pixels < 0.02:
+            i = re.findall(r"\d+", fov)[0]
+            custom_name = run_metadata["fovs"][int(i) - 1]["name"]
+            incomplete_fovs[fov] = custom_name
+
+    if incomplete_fovs:
+        incomplete_fovs = pd.DataFrame(incomplete_fovs, index=[0]).T
+        incomplete_fovs.columns = ["fov_name"]
+        warnings.warn(
+            "The following FOVs were only partially generated and need to be re-ran: \n"
+            f"{incomplete_fovs}"
+        )

--- a/src/toffy/watcher_callbacks.py
+++ b/src/toffy/watcher_callbacks.py
@@ -15,6 +15,7 @@ from alpineer import io_utils, misc_utils
 from mibi_bin_tools.bin_files import _write_out, extract_bin_files
 from mibi_bin_tools.type_utils import any_true
 
+from toffy.bin_extraction import incomplete_fov_check
 from toffy.image_stitching import stitch_images
 from toffy.mph_comp import combine_mph_metrics, compute_mph_metrics, visualize_mph
 from toffy.normalize import write_mph_per_mass
@@ -116,6 +117,13 @@ class RunCallbacks:
         viz_kwargs = {k: v for k, v in kwargs.items() if k in valid_kwargs}
 
         stitch_images(tiff_out_dir, self.run_folder, **viz_kwargs)
+
+    def check_incomplete_fovs(self, **kwargs):
+        """Checks for partial images (even when fully extracted)
+        Raises:
+            Warning if any  FOVs have partially generated images
+        """
+        incomplete_fov_check(self.run_folder, os.path.basename(self.run_folder))
 
 
 @dataclass

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -173,7 +173,7 @@ FOV_CALLBACKS = (
     "generate_mph",
     "generate_pulse_heights",
 )
-RUN_CALLBACKS = ("plot_qc_metrics", "plot_mph_metrics", "image_stitching")
+RUN_CALLBACKS = ("plot_qc_metrics", "plot_mph_metrics", "image_stitching", "check_incomplete_fovs")
 
 
 def mock_visualize_qc_metrics(
@@ -558,7 +558,7 @@ class WatcherCases:
         kwargs = {"panel": panel, "intensities": intensity, "replace": replace}
 
         return (
-            ["plot_qc_metrics", "plot_mph_metrics", "image_stitching"],
+            ["plot_qc_metrics", "plot_mph_metrics", "image_stitching", "check_incomplete_fovs"],
             None,
             ["extract_tiffs", "generate_pulse_heights"],
             kwargs,


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #400. Checks for incomplete FOV images which are missing data.

**How did you implement your changes**

Since scanning during a run starts at the top of the FOV, if something goes wrong we see this resulting in mostly 0 signal values at the bottom of the image. To be thorough, we check a specified number of images (default 5), and if the amount of non-zero pixels in that last 10 rows is less than 2%, we can identify this as a partial FOV.

**Remaining issues**
N/A
