### PR TITLE
Compress rosetta tile

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -514,7 +514,7 @@ def create_tiled_comparison(
         if img_size_scale:
             tiled_image = rescale_images(tiled_image, img_size_scale)
         fname = os.path.join(output_dir, channels[j] + "_comparison.tiff")
-        image_utils.save_image(fname, tiled_image)
+        image_utils.save_image(fname, np.round(tiled_image, 3))
 
 
 def add_source_channel_to_tiled_image(
@@ -580,7 +580,7 @@ def add_source_channel_to_tiled_image(
         # combine together and save
         combined_tile = np.concatenate([rescaled_source, current_tile])
         save_name = tile_name.split(".tiff")[0] + "_source_" + source_channel + ".tiff"
-        image_utils.save_image(os.path.join(output_dir, save_name), combined_tile)
+        image_utils.save_image(os.path.join(output_dir, save_name), np.round(combined_tile, 3))
 
 
 def replace_with_intensity_image(run_dir, channel="Au", replace=True, fovs=None):

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -514,6 +514,8 @@ def create_tiled_comparison(
         if img_size_scale:
             tiled_image = rescale_images(tiled_image, img_size_scale)
         fname = os.path.join(output_dir, channels[j] + "_comparison.tiff")
+
+        # save, compress to 3 decimal points for space optimization
         image_utils.save_image(fname, np.round(tiled_image, 3))
 
 
@@ -577,7 +579,7 @@ def add_source_channel_to_tiled_image(
 
         rescaled_source = source_row / perc_ratio
 
-        # combine together and save
+        # combine together and save, compress to 3 decimal points for space optimization
         combined_tile = np.concatenate([rescaled_source, current_tile])
         save_name = tile_name.split(".tiff")[0] + "_source_" + source_channel + ".tiff"
         image_utils.save_image(os.path.join(output_dir, save_name), np.round(combined_tile, 3))


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #402. Stitched Rosetta images are too large, adds further compression to reduce size.

**How did you implement your changes**

Truncate the tiled Rosetta images to 3 decimal places to ensure faster saving and reading in Photoshop. This also provides a free NAS storage optimization.