### PR TITLE
Provide more robust round 1 -> round 2 copying

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -422,7 +422,7 @@ def copy_round_one_compensated_images(
     r1_runs = io_utils.list_folders(round_one_comp_folder)
     r2_runs = io_utils.list_folders(round_two_comp_folder)
     misc_utils.verify_in_list(provided_runs=runs, round_one_comp_runs=r1_runs)
-    misc_utils.verify_in_list(provided_runs=runs, round_two_comp_runs=r1_runs)
+    misc_utils.verify_in_list(provided_runs=runs, round_two_comp_runs=r2_runs)
 
     # for each FOV, copy the channel from their r1_runs folder to r2_runs folder
     for run in runs:

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -402,27 +402,30 @@ def compensate_image_data(
 
 
 def copy_round_one_compensated_images(
-    round_one_comp_folder, round_two_comp_folder, channels_to_copy
+    runs, round_one_comp_folder, round_two_comp_folder, channels_to_copy
 ):
     """Copies channels that don't need round two compensation to the round two comp folder
 
     Args:
+        runs (list):
+            runs in `round_two_comp_folder` that need copying from `round_one_comp_folder`
         round_one_comp_folder (str):
             path to the round one Rosetta compensated images
         round_two_comp_folder (str):
             path to the round two Rosetta compensated images
         channels_to_copy (list):
-            channels to copy from round_one_comp_folder to round_two_comp_folder
+            channels to copy from `round_one_comp_folder` to `round_two_comp_folder`
     """
     io_utils.validate_paths([round_one_comp_folder, round_two_comp_folder])
 
-    # verify runs found in round two Rosetta folder also found in round one Rosetta folders
+    # verify runs found in both round one and round two Rosetta folders
     r1_runs = io_utils.list_folders(round_one_comp_folder)
     r2_runs = io_utils.list_folders(round_two_comp_folder)
-    misc_utils.verify_in_list(round_one_comp_fovs=r1_runs, round_two_comp_fovs=r2_runs)
+    misc_utils.verify_in_list(provided_runs=runs, round_one_comp_runs=r1_runs)
+    misc_utils.verify_in_list(provided_runs=runs, round_two_comp_runs=r1_runs)
 
     # for each FOV, copy the channel from their r1_runs folder to r2_runs folder
-    for run in r2_runs:
+    for run in runs:
         fovs = io_utils.list_folders(os.path.join(round_one_comp_folder, run), substrs="fov")
 
         for fov in fovs:

--- a/templates/4a_compensate_image_data_round2.ipynb
+++ b/templates/4a_compensate_image_data_round2.ipynb
@@ -415,7 +415,7 @@
     "                                  raw_data_sub_folder='rescaled', batch_size=1,\n",
     "                                  gaus_rad=0, norm_const=1, output_masses=output_masses)\n",
     "\n",
-    "rosetta.copy_round_one_compensated_images(rosetta_round_one_dir, rosetta_round_two_dir, non_output_targets)"
+    "rosetta.copy_round_one_compensated_images(runs, rosetta_round_one_dir, rosetta_round_two_dir, non_output_targets)"
    ]
   }
  ],

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -402,7 +402,7 @@ def test_copy_round_one_compensated_images():
 
         # copy the images and assert all channels exist in round two folder
         rosetta.copy_round_one_compensated_images(
-            round_one_folder, round_two_folder, channel_list[:2]
+            runs, round_one_folder, round_two_folder, channel_list[:2]
         )
 
         for run in runs:


### PR DESCRIPTION
**What is the purpose of this PR?**

If the round 1 Rosetta folder diverges from the round 2 Rosetta folder (ex. CAC deletion), the current version of `copy_round_one_compensated_images` will fail. Ensure that this does not happen.

**How did you implement your changes**

Explicitly specify the list of `runs` provided in the 4a round 2 notebook to the function.