### PR TITLE
Standardize indexing of over- and under-normalized channels in `normalize_fov`

### DIFF
--- a/src/toffy/normalize.py
+++ b/src/toffy/normalize.py
@@ -729,7 +729,7 @@ def normalize_fov(img_data, norm_vals, norm_dir, fov, channels, extreme_vals):
         os.makedirs(output_fov_dir)
 
     # cap maximum normalization increase at 10X, ignore 0 (skipped) norm_vals
-    abnormal_increase_mask = np.where(np.logical_and(norm_vals > 0, norm_vals < 0.1))
+    abnormal_increase_mask = np.where(np.logical_and(norm_vals > 0, norm_vals < 0.1))[0]
     if len(abnormal_increase_mask) > 0:
         abnormal_increase_chans = np.array(channels)[abnormal_increase_mask]
         warnings.warn(


### PR DESCRIPTION
**What is the purpose of this PR?**

Fixes a bug that incorrectly prints out blank arrays when determining over- and under-normalized channels.

**How did you implement your changes**

Ensures the list of channel indices are extracted using [0].