### PR TITLE
Ensure low sensitivity normalization correction works with negative values too

### DIFF
--- a/src/toffy/normalize.py
+++ b/src/toffy/normalize.py
@@ -729,7 +729,7 @@ def normalize_fov(img_data, norm_vals, norm_dir, fov, channels, extreme_vals):
         os.makedirs(output_fov_dir)
 
     # cap maximum normalization increase at 10X, ignore 0 (skipped) norm_vals
-    abnormal_increase_mask = np.where(np.logical_and(norm_vals > 0, norm_vals < 0.1))[0]
+    abnormal_increase_mask = np.where(np.logical_and(norm_vals < 0.1, norm_vals != 0))[0]
     if len(abnormal_increase_mask) > 0:
         abnormal_increase_chans = np.array(channels)[abnormal_increase_mask]
         warnings.warn(

--- a/tests/normalize_test.py
+++ b/tests/normalize_test.py
@@ -573,7 +573,7 @@ def test_normalize_fov(tmpdir, test_zeros, test_high_norm, test_low_norm):
 
     # if test_high_norm, set norm vals lower than 0.1
     if test_high_norm:
-        norm_vals[1] = 0.01
+        norm_vals[1] = -0.01
         norm_mults[1] = 0.1
 
     # if test_low_norm, set norm vals higher than 1


### PR DESCRIPTION
**What is the purpose of this PR?**

`normalize_fov` should correctly cap negative normalization at 10X as well. Previously, it was assumed that norm_coefficients had to be positive, otherwise there was an underlying issue with the norm_curve itself.

**How did you implement your changes**

Change the `np.logical_and` check. Previously, it ignored all norm_coeffs < 0. Now, it only ignores norm_coeffs == 0 (a blank channel), and adds the 10X cap to all other norm_coeffs < 0.1.