### PR TITLE
Check for all run merge conflicts 

### DIFF
--- a/src/toffy/reorg.py
+++ b/src/toffy/reorg.py
@@ -26,6 +26,7 @@ def merge_partial_runs(cohort_dir, run_string):
         raise ValueError("No matching folders found for {}".format(run_string))
 
     # loop through each partial folder
+    duplicates = []
     for partial in partial_folders:
         fov_folders = io_utils.list_folders(os.path.join(cohort_dir, partial))
 
@@ -33,12 +34,16 @@ def merge_partial_runs(cohort_dir, run_string):
         for fov in fov_folders:
             new_path = os.path.join(output_folder, fov)
             if os.path.exists(new_path):
-                raise ValueError(
-                    "The following folder {} already exists in {}. If there are "
-                    "duplicates in your partial run folders, you'll need to determine"
-                    " which to keep before merging".format(fov, output_folder)
-                )
-            shutil.move(os.path.join(cohort_dir, partial, fov), new_path)
+                duplicates.append(fov)
+            else:
+                shutil.move(os.path.join(cohort_dir, partial, fov), new_path)
+
+        if duplicates:
+            raise ValueError(
+                "The following folders already exist in {}: {}. If there are "
+                "duplicates in your partial run folders, you'll need to determine"
+                " which to keep before merging".format(output_folder, duplicates)
+            )
 
         # remove partial folder
         shutil.rmtree(os.path.join(cohort_dir, partial))

--- a/src/toffy/reorg.py
+++ b/src/toffy/reorg.py
@@ -27,9 +27,10 @@ def merge_partial_runs(cohort_dir, run_string):
         raise ValueError("No matching folders found for {}".format(run_string))
 
     # duplicate fovs check
-    fovs_by_folder = {}
-    for partial in partial_folders:
-        fovs_by_folder[partial] = io_utils.list_folders(os.path.join(cohort_dir, partial))
+    fovs_by_folder = {
+        partial: io_utils.list_folders(os.path.join(cohort_dir, partial))
+        for partial in partial_folders
+    }
     fov_names = [
         fov for partial_folder_fovs in fovs_by_folder.values() for fov in partial_folder_fovs
     ]

--- a/src/toffy/reorg.py
+++ b/src/toffy/reorg.py
@@ -2,8 +2,6 @@ import os
 import shutil
 from collections import Counter
 
-import numpy as np
-import pandas as pd
 from alpineer import io_utils, misc_utils
 
 from toffy.json_utils import read_json_file, rename_duplicate_fovs, rename_missing_fovs

--- a/src/toffy/reorg.py
+++ b/src/toffy/reorg.py
@@ -39,15 +39,12 @@ def merge_partial_runs(cohort_dir, run_string):
 
     # raise error to report any duplicate fovs
     if duplicate_fovs:
-        duplicate_info = {}
         for fov in duplicate_fovs:
-            duplicate_info[fov] = [
-                run_name for run_name, run_fovs in fovs_by_folder.items() if fov in run_fovs
-            ]
+            runs = [run_name for run_name, run_fovs in fovs_by_folder.items() if fov in run_fovs]
+            print(f"{fov}: {runs}")
         raise ValueError(
-            f'There are duplicate folders among runs containing the name "{run_string}".\n'
-            "You'll need to determine which folder to keep and which to delete before merging.\n"
-            f"{pd.DataFrame(duplicate_info).to_string(index=False)}"
+            f"The following FOV folders exist in multiple partial runs: {duplicate_fovs}\n"
+            "You need to determine which folders to keep and which to delete before merging."
         )
 
     # loop through each partial run folder and move the fov folders

--- a/tests/reorg_test.py
+++ b/tests/reorg_test.py
@@ -64,7 +64,12 @@ def test_merge_partial_runs(tmpdir):
 
     # check that duplicate FOVs raises error
     os.makedirs(os.path.join(tmpdir, "run1_start", "fov2"))
-    with pytest.raises(ValueError, match="folder fov2 already exists"):
+    with pytest.raises(ValueError, match="['fov2']"):
+        reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="run1")
+
+    # check multiple duplicate FOVs works
+    os.makedirs(os.path.join(tmpdir, "run1_start", "fov3"))
+    with pytest.raises(ValueError, match="['fov3', 'fov2']"):
         reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="run1")
 
 

--- a/tests/reorg_test.py
+++ b/tests/reorg_test.py
@@ -63,14 +63,16 @@ def test_merge_partial_runs(tmpdir):
         reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="run4")
 
     # check that duplicate FOVs raises error
-    os.makedirs(os.path.join(tmpdir, "run1_start", "fov2"))
-    with pytest.raises(ValueError, match="['fov2']"):
-        reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="run1")
+    for run, fovs in zip(["run_dup", "run_dup2"], [["fov1"], ["fov1", "fov2"]]):
+        for fov in fovs:
+            os.makedirs(os.path.join(tmpdir, run, fov))
+    with pytest.raises(ValueError, match="fov1"):
+        reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="dup")
 
-    # check multiple duplicate FOVs works
-    os.makedirs(os.path.join(tmpdir, "run1_start", "fov3"))
-    with pytest.raises(ValueError, match="['fov3', 'fov2']"):
-        reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="run1")
+    # check multiple duplicate FOVs (in different runs) works
+    os.makedirs(os.path.join(tmpdir, "run_dup3", "fov2"))
+    with pytest.raises(ValueError, match="fov2"):
+        reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="dup")
 
 
 def test_combine_runs(tmpdir):

--- a/tests/reorg_test.py
+++ b/tests/reorg_test.py
@@ -71,6 +71,7 @@ def test_merge_partial_runs(tmpdir):
 
     # check multiple duplicate FOVs (in different runs) works
     os.makedirs(os.path.join(tmpdir, "run_dup3", "fov2"))
+    os.makedirs(os.path.join(tmpdir, "run_dup4", "fov2"))
     with pytest.raises(ValueError, match="fov2"):
         reorg.merge_partial_runs(cohort_dir=tmpdir, run_string="dup")
 


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #430. Adjusts `reorg.merge_partial_runs()` to check for duplicate FOV names across all of the runs being combined before moving any folders. 

**How did you implement your changes**

Get the lists of folder names for all runs identified, and check for any duplicate FOV names. If duplicates exist, raise an error that prints the duplicate FOV names and the runs which they belong so the user can delete/change the appropriate folders.

**Remaining issues**

N/A
