### PR TITLE
Ensure safe conversion of panel types during `modify_panel_ranges`

### DIFF
--- a/src/toffy/panel_utils.py
+++ b/src/toffy/panel_utils.py
@@ -129,8 +129,8 @@ def modify_panel_ranges(panel: pd.DataFrame, start_offset: float = 0, stop_offse
     ].index.values
 
     # ensure safe conversion of types
-    panel_new["Start"] = panel_new["Start"].astype(np.float16)
-    panel_new["Stop"] = panel_new["Stop"].astype(np.float16)
+    panel_new["Start"] = panel_new["Start"].astype(np.float64)
+    panel_new["Stop"] = panel_new["Stop"].astype(np.float64)
 
     # add start_offset to 'Start' column
     panel_new.loc[panel_rows_modify, "Start"] = (

--- a/src/toffy/panel_utils.py
+++ b/src/toffy/panel_utils.py
@@ -129,8 +129,8 @@ def modify_panel_ranges(panel: pd.DataFrame, start_offset: float = 0, stop_offse
     ].index.values
 
     # ensure safe conversion of types
-    panel_new["Start"] = panel_new["Start"].astype(np.float64)
-    panel_new["Stop"] = panel_new["Stop"].astype(np.float64)
+    panel_new["Start"] = panel_new["Start"].astype(np.float16)
+    panel_new["Stop"] = panel_new["Stop"].astype(np.float16)
 
     # add start_offset to 'Start' column
     panel_new.loc[panel_rows_modify, "Start"] = (

--- a/src/toffy/panel_utils.py
+++ b/src/toffy/panel_utils.py
@@ -1,5 +1,6 @@
 import os
 
+import numpy as np
 import pandas as pd
 from alpineer import io_utils
 
@@ -126,6 +127,10 @@ def modify_panel_ranges(panel: pd.DataFrame, start_offset: float = 0, stop_offse
     panel_rows_modify = panel_new[
         (panel_new["Start"] - panel_new["Stop"]).round(1) == -0.3
     ].index.values
+
+    # ensure safe conversion of types
+    panel_new["Start"] = panel_new["Start"].astype(np.float64)
+    panel_new["Stop"] = panel_new["Stop"].astype(np.float64)
 
     # add start_offset to 'Start' column
     panel_new.loc[panel_rows_modify, "Start"] = (

--- a/templates/3b_extract_images_from_bin.ipynb
+++ b/templates/3b_extract_images_from_bin.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import os\n",
     "\n",
-    "from toffy.panel_utils import load_panel\n",
+    "from toffy.panel_utils import load_panel, modify_panel_ranges\n",
     "from toffy.bin_extraction import extract_missing_fovs, incomplete_fov_check"
    ]
   },
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "incomplete_fov_check(bin_file_dir, extraction_dir)"
+    "incomplete_fov_check(base_dir, extraction_dir)"
    ]
   }
  ],


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #442. A future `pandas` version will error out on `int` to `float` conversions, so we modify that to suppress the warning.

**How did you implement your changes**

Add the following lines:

```
panel_new["Start"] = panel_new["Start"].astype(np.float64)
panel_new["Stop"] = panel_new["Stop"].astype(np.float64)
```

prior to adding the offsets.