### PR TITLE
Prevent mass column from adding during `rosetta.combine_compensation_files`

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -188,9 +188,10 @@ def combine_compensation_files(comp_matrix_path, compensation_matrix_names, fina
     )
 
     # loop over the rest and add them in
+    # NOTE: skip the first column, since that just delineates the channels
     for matrix in compensation_matrix_names[1:]:
-        final_compensation_matrix = final_compensation_matrix.add(
-            pd.read_csv(os.path.join(comp_matrix_path, matrix))
+        final_compensation_matrix.iloc[:, 1:] = final_compensation_matrix.iloc[:, 1:].add(
+            pd.read_csv(os.path.join(comp_matrix_path, matrix)).iloc[:, 1:]
         )
 
     # save the final compensation matrix to final_matrix_name

--- a/tests/rosetta_test.py
+++ b/tests/rosetta_test.py
@@ -241,10 +241,11 @@ def test_combine_compensation_files():
         for m in mults:
             for cp in channel_pairs:
                 df = pd.DataFrame(
-                    np.zeros((3, 3)),
+                    np.zeros((3, 4)),
                     index=channels,
-                    columns=channels,
+                    columns=[None] + channels,
                 )
+                df.iloc[:, 0] = np.arange(3)
                 df.loc[cp[0], cp[1]] = m
                 df.to_csv(
                     os.path.join(rosetta_test_dir, f"{cp[0]}_{cp[1]}_compensation_matrix_{m}.csv"),
@@ -261,12 +262,18 @@ def test_combine_compensation_files():
             rosetta_test_dir, compensation_matrices, "final_rosetta_matrix.csv"
         )
 
-        # assert final_rosetta_matrix.csv created and generated correctly
+        # assert final_rosetta_matrix.csv created
         final_rosetta_matrix_path = os.path.join(rosetta_test_dir, "final_rosetta_matrix.csv")
         assert os.path.exists(final_rosetta_matrix_path)
+
+        # assert the compensation coefficients got combined correctly
         final_rosetta_matrix = pd.read_csv(final_rosetta_matrix_path)
         actual_final_values = np.array([[0, 0.5, 0], [0, 0, 1], [2, 0, 0]])
-        assert np.all(final_rosetta_matrix.values == actual_final_values)
+        assert np.all(final_rosetta_matrix.values[:, 1:] == actual_final_values)
+
+        # assert the channel column didn't get modified
+        actual_column_values = np.arange(3)
+        assert np.all(final_rosetta_matrix.iloc[:, 0].values == actual_column_values)
 
 
 def test_flat_field_correction():


### PR DESCRIPTION
**What is the purpose of this PR?**

If multiple round 2 channel pairs need to be handled, more than 1 round 2 compensation matrix will need to be combined. The compensation values themselves combine correctly, but because the first column (the noisy masses) gets read in as an actual `pandas` column, and not an index, those will also get added together, creating a final noisy mass column that's incorrectly `num_comp_matrices_combine * mass_vals`.

**How did you implement your changes**

Ensure the first column doesn't get added during this process.

**Remaining issues**

We should strongly consider changing the way we load in Rosetta compensation matrices during the entire process. It's very inconvenient to have the noisy mass values as a separate column and not an index, especially when the masses to denoise are read in as Pandas columns.