### PR TITLE
Prevent pulse_height_fit from throwing dtype warning with floats

### DIFF
--- a/src/toffy/normalize.py
+++ b/src/toffy/normalize.py
@@ -638,7 +638,7 @@ def create_fitted_mass_mph_vals(pulse_height_df, obj_func_dir):
     masses = np.unique(pulse_height_df["mass"].values)
 
     # create column to hold fitted values
-    pulse_height_df["pulse_height_fit"] = 0
+    pulse_height_df["pulse_height_fit"] = 0.0
 
     # create x axis values
     num_fovs = len(np.unique(pulse_height_df["fov"]))


### PR DESCRIPTION
**What is the purpose of this PR?**

When trying to set floating point values to `pulse_height_fit`, the new standard for `pandas` will throw a warning because we initialized them with the _integer_ 0.

**How did you implement your changes**

Instead of initializing with 0, initialize with 0.0 so floating point values are used.