### PR TITLE
Normalization notebook bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ conda env create -f release-environment.yml
 or
 
 ```shell
-conda env remove --name toffy_prerelease_env --all
+conda remove --name toffy_prerelease_env --all
 conda env create -f prerelease-environment.yml
 ```
 

--- a/templates/4b_normalize_image_data.ipynb
+++ b/templates/4b_normalize_image_data.ipynb
@@ -85,17 +85,7 @@
     "bin_base_dir = 'D:\\\\Data'\n",
     "rosetta_base_dir = 'D:\\\\Rosetta_Compensated_Images'\n",
     "normalized_base_dir = 'D:\\\\Normalized_Images'\n",
-    "mph_run_dir = os.path.join('C:\\\\Users\\\\Customer.ION\\\\Documents\\\\run_metrics', run_name, 'fov_data')\n",
-    "\n",
-    "# plot the voltage change across FOVs if autogain set\n",
-    "# otherwise, verify the voltage across all FOVs is constant\n",
-    "if autogain:\n",
-    "    normalize.plot_detector_voltage(\n",
-    "        run_folder=os.path.join(bin_base_dir, run_name),\n",
-    "        mph_run_dir=os.path.dirname(mph_run_dir)\n",
-    "    )\n",
-    "else:\n",
-    "    normalize.check_detector_voltage(os.path.join(bin_base_dir, run_name))"
+    "mph_run_dir = os.path.join('C:\\\\Users\\\\Customer.ION\\\\Documents\\\\run_metrics', run_name, 'fov_data')"
    ]
   },
   {
@@ -103,7 +93,7 @@
    "id": "62142cdc-fb78-4c21-8cb2-77b3fb60d399",
    "metadata": {},
    "source": [
-    "### Within the defined directories, we'll specify the relevant run_dir based on the run_name provided above"
+    "### Within the defined directories, we'll specify the relevant folders based on the run_name provided above"
    ]
   },
   {
@@ -124,6 +114,24 @@
     "# create directory to hold associated processing files\n",
     "if not os.path.exists(mph_run_dir):\n",
     "    os.makedirs(mph_run_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26a674b2-e6f1-4886-b93f-0a14f24e86db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the voltage change across FOVs if autogain set\n",
+    "# otherwise, verify the voltage across all FOVs is constant\n",
+    "if autogain:\n",
+    "    normalize.plot_detector_voltage(\n",
+    "        run_folder=os.path.join(bin_base_dir, run_name),\n",
+    "        mph_run_dir=os.path.dirname(mph_run_dir)\n",
+    "    )\n",
+    "else:\n",
+    "    normalize.check_detector_voltage(os.path.join(bin_base_dir, run_name))"
    ]
   },
   {
@@ -193,7 +201,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

In the normalization notebook, `mph_run_dir` is passed into `plot_detector_voltage()` before it is created, which causes an error if a user it running 4b without running the watcher notebook first.

Also fixes a minor readme typo.

**How did you implement your changes**

Simply move up the `os.makedirs()` call in the notebook, to avoid any issues.

**Remaining issues**

NA
