### PR TITLE
Fix Noodle extraction range in convert_panel()

### DIFF
--- a/src/toffy/panel_utils.py
+++ b/src/toffy/panel_utils.py
@@ -238,6 +238,9 @@ def convert_panel(panel_path):
     toffy_panel["Start"] = toffy_panel["Mass"].copy() - 0.3
     toffy_panel["Stop"] = toffy_panel["Mass"].copy()
 
+    # specify 116.7 - 125 Noodle extraction range
+    toffy_panel.loc[toffy_panel.Mass == 117, "Stop"] = 125
+
     # sort data by mass
     toffy_panel = toffy_panel.sort_values(by=["Mass"])
 

--- a/tests/panel_utils_test.py
+++ b/tests/panel_utils_test.py
@@ -129,6 +129,9 @@ def test_convert_panel():
             mass in list(converted_panel["Mass"]) for mass in (list(necessary_panel["Mass"]))
         )
 
+        # check for correct Noodle extraction range
+        assert converted_panel[converted_panel.Mass == 117].Stop.values[0] == 125
+
         # check that correctly formatted panel loads without issue
         converted_panel.to_csv(os.path.join(temp_dir, "converted_panel.csv"), index=False)
         result_panel = panel_utils.convert_panel(os.path.join(temp_dir, "converted_panel.csv"))


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Closes #463.
Currently, when the toffy panel is created, the extraction range is set to `Start = Mass - 0.3` and `Stop = Mass`. For the Noodle channel specifically (mass 117), the range needs a custom Stop value of 125.

**How did you implement your changes**

Adjust the `convert_panel()` function.

**Remaining issues**

This will fix future default panel creation, but anyone who has already generated a `-toffy.csv` panel file will need to manually adjust the Noodle range.
