### PR TITLE
Support legacy panel files defined before the Noodle range extraction fix

### DIFF
--- a/src/toffy/panel_utils.py
+++ b/src/toffy/panel_utils.py
@@ -274,6 +274,7 @@ def load_panel(panel_path):
                 "'-toffy' from the file name."
             )
         else:
+            toffy_panel.loc[toffy_panel.Mass == 117, "Stop"] = 125
             print(f"{panel_name}.csv is in the correct toffy format. Loading in panel data.")
     else:
         # check if toffy panel exists in panel_dir and load it
@@ -281,6 +282,7 @@ def load_panel(panel_path):
         if panel_name + "-toffy.csv" in files:
             converted_panel_path = os.path.join(panel_dir, panel_name + "-toffy.csv")
             toffy_panel = pd.read_csv(converted_panel_path, index_col=False)
+            toffy_panel.loc[toffy_panel.Mass == 117, "Stop"] = 125
             print(
                 f"Detected {panel_name}-toffy.csv in {panel_dir}. "
                 "Loading in toffy formatted panel data."

--- a/tests/panel_utils_test.py
+++ b/tests/panel_utils_test.py
@@ -156,10 +156,10 @@ def test_load_panel(mocker):
     mocker.patch("toffy.panel_utils.convert_panel", mock_panel_conversion)
     toffy_panel = pd.DataFrame(
         {
-            "Mass": [69, 71, 89],
-            "Target": ["Calprotectin", "Chymase", "Mast Cell Tryptase"],
-            "Start": [68.7, 70.7, 88.7],
-            "Stop": [69, 71, 89],
+            "Mass": [69, 71, 89, 117],
+            "Target": ["Calprotectin", "Chymase", "Mast Cell Tryptase", "Noodle"],
+            "Start": [68.7, 70.7, 88.7, 116.7],
+            "Stop": [69, 71, 89, 117],
         }
     )
 
@@ -176,8 +176,9 @@ def test_load_panel(mocker):
         # toffy panel
         toffy_panel.to_csv(os.path.join(temp_dir, "test_panel-toffy.csv"), index=False)
 
-        # check that previously converted panel is loaded
+        # check that previously converted panel is loaded with Noodle channel corrected
         panel = panel_utils.load_panel(os.path.join(temp_dir, "test_panel-toffy.csv"))
+        toffy_panel.loc[toffy_panel["Target"] == "Noodle", "Stop"] = 125
         assert panel.equals(toffy_panel)
 
         # check that original panel is not read in if converted already exists


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #468.

**How did you implement your changes**

Explicitly update the Noodle extraction range on pre-loaded panel files in `load_panel`.