### PR TITLE
Normalize by maximum pixel in case of Rosetta tiling for sparse signal 

### DIFF
--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -559,7 +559,7 @@ def add_source_channel_to_tiled_image(
     perc_source = np.percentile(source_scaled, percent_norm) if percent_norm else None
 
     # normalize by max if percent_norm is 0 for source in case of sparse signal
-    if perc_source == 0:
+    if percent_norm and perc_source == 0:
         perc_source = np.percentile(source_scaled, 100)
 
     # confirm tiled images have expected shape

--- a/src/toffy/rosetta.py
+++ b/src/toffy/rosetta.py
@@ -558,6 +558,10 @@ def add_source_channel_to_tiled_image(
     # get percentile of source row if percent_norm set, otherwise leave unset
     perc_source = np.percentile(source_scaled, percent_norm) if percent_norm else None
 
+    # normalize by max if percent_norm is 0 for source in case of sparse signal
+    if perc_source == 0:
+        perc_source = np.percentile(source_scaled, 100)
+
     # confirm tiled images have expected shape
     tiled_images = io_utils.list_files(tiled_img_dir)
     test_file = io.imread(os.path.join(tiled_img_dir, tiled_images[0]))
@@ -577,6 +581,11 @@ def add_source_channel_to_tiled_image(
         perc_ratio = 1
         if percent_norm:
             perc_tile = np.percentile(current_tile, percent_norm)
+
+            # normalize by max if percent_norm is 0 for tile in case of sparse signal
+            if perc_tile == 0:
+                perc_tile = np.percentile(current_tile, 100)
+
             perc_ratio = perc_source / perc_tile
 
         rescaled_source = source_scaled / perc_ratio


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #469.

**How did you implement your changes**

If the percent norm for either source or tile is 0 at the given `percent_norm`, default to normalizing by the maximum pixel intensity in the image. This will ensure that normalization is possible and should only happen if the signal is extremely sparse.

**Remaining issues**

This process will still fail in case of a blank source or tile, but that should not happen with proper run and extraction settings.