### PR TITLE
Fix `incomplete_fov_check` to not require a channel named `Au`

### DIFF
--- a/src/toffy/bin_extraction.py
+++ b/src/toffy/bin_extraction.py
@@ -99,12 +99,14 @@ def incomplete_fov_check(
     run_file_path = os.path.join(bin_file_dir, run_name + ".json")
     run_metadata = read_json_file(run_file_path, encoding="utf-8")
 
-    # get fov and channel info
-    fovs = io_utils.list_folders(extraction_dir, "fov")
+    # TODO: list_folders does not handle cases such as "fov0" correctly
+    # need to add a fix in to alpineer to deal with this
+    fovs = [f for f in os.listdir(extraction_dir) if "fov" in f]
+
+    # NOTE: the specifically-named "Au" channel is no longer be assumed to be present
+    # simply check the first 5 channels found
     channels = io_utils.list_files(os.path.join(extraction_dir, fovs[0]), ".tiff")
     channels_subset = channels[:num_channels]
-    if "Au.tiff" not in channels_subset:
-        channels_subset = channels_subset[:-1] + ["Au.tiff"]
 
     incomplete_fovs = {}
     for fov in fovs:

--- a/templates/3a_monitor_MIBI_run.ipynb
+++ b/templates/3a_monitor_MIBI_run.ipynb
@@ -77,6 +77,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the specific channels you want to extract as intensity images, leave list empty if there are none\n",
+    "# NOTE: these must match names found in panel_path\n",
+    "intensity_channels = [\"Au\", \"chan_39\"]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -125,6 +136,7 @@
     "    save_dir=metrics_plot_dir,\n",
     "    panel=panel,\n",
     "    warn_overwrite=False,\n",
+    "    intensities=intensity_channels,\n",
     ")"
    ]
   },
@@ -154,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.9"
   },
   "vscode": {
    "interpreter": {

--- a/templates/3b_extract_images_from_bin.ipynb
+++ b/templates/3b_extract_images_from_bin.ipynb
@@ -101,16 +101,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "27887a2a-3dc7-4c7a-ac44-e404c29ff112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the specific channels you want to extract as intensity images, leave list empty if there are none\n",
+    "# NOTE: these must match names found in panel_path\n",
+    "intensity_channels = [\"Au\", \"chan_39\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "cd6eda88-3003-496f-8c66-1697d570f05d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# base deficient extraction\n",
-    "extract_missing_fovs(base_dir, extraction_dir, panel)\n",
+    "extract_missing_fovs(\n",
+    "    base_dir,\n",
+    "    extraction_dir,\n",
+    "    panel,\n",
+    "    extract_intensities=intensity_channels,\n",
+    ")\n",
     "\n",
     "# mass proficient extraction (for long-term storage)\n",
     "if extract_prof:\n",
-    "    extract_missing_fovs(base_dir, extraction_prof_dir, modify_panel_ranges(panel, start_offset=0.3, stop_offset=0.3))"
+    "    extract_missing_fovs(\n",
+    "        base_dir,\n",
+    "        extraction_prof_dir,\n",
+    "        modify_panel_ranges(panel, start_offset=0.3, stop_offset=0.3),\n",
+    "        extract_intensities=intensity_channels,\n",
+    "    )"
    ]
   },
   {
@@ -149,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**What is the purpose of this PR?**

Closes #473.

**How did you implement your changes**

Remove the addition of the `"Au"` channel in `incomplete_fov_check`.

Add specific lists in the `3a` and `3b` notebooks to allow the user to change their intensity channels they wish to extract (or leave as blank of none specified).