### PR TITLE
Fix release issue inconsistency on PyPI

### DIFF
--- a/release-environment.yml
+++ b/release-environment.yml
@@ -13,4 +13,4 @@ dependencies:
     - alpineer>=0.1.10
     - mibi-bin-tools==0.2.12
     - jupyter_contrib_nbextensions
-    - toffy==0.2.3
+    - toffy==0.3.1


### PR DESCRIPTION
**What is the purpose of this PR?**

Need to fix a tag-related issue where the PyPI release cannot be overwritten even if the release tag changes locally. This arose because of an issue creating the tag from the default release drafter name.

**How did you implement your changes**

Bump release-environment.yml to v0.3.1.