### PR TITLE
Fix mibi-bin-tools release to 0.2.14

### DIFF
--- a/prerelease-environment.yml
+++ b/prerelease-environment.yml
@@ -12,6 +12,6 @@ dependencies:
     - natsort
     - watchdog
     - alpineer>=0.1.10
-    - mibi-bin-tools==0.2.12
+    - mibi-bin-tools==0.2.14
     - jupyter_contrib_nbextensions
     - -e .

--- a/release-environment.yml
+++ b/release-environment.yml
@@ -11,6 +11,6 @@ dependencies:
     - natsort
     - watchdog
     - alpineer>=0.1.10
-    - mibi-bin-tools==0.2.12
+    - mibi-bin-tools==0.2.14
     - jupyter_contrib_nbextensions
     - toffy==0.3.1


### PR DESCRIPTION
**What is the purpose of this PR?**

Resolves another issue where `mibi-bin-tools` was explicitly pinned in the release environments. This has been updated.

**Remaining issues**

Do we still want this pin?
