### PR TITLE
Bump `toffy` to 0.3.3

### DIFF
--- a/release-environment.yml
+++ b/release-environment.yml
@@ -13,4 +13,4 @@ dependencies:
     - alpineer>=0.1.10
     - mibi-bin-tools==0.2.14
     - jupyter_contrib_nbextensions
-    - toffy==0.3.1
+    - toffy==0.3.3


### PR DESCRIPTION
**What is the purpose of this PR?**

This (should) hopefully be the final fix. There is an error in the release environment that will download 0.3.1 instead.