### PR TITLE
Fix broken environment creation with `pip` installation of `jupyter_contrib_nbextensions`

### DIFF
--- a/prerelease-environment.yml
+++ b/prerelease-environment.yml
@@ -7,11 +7,12 @@ dependencies:
   - numpy
   - seaborn
   - scikit-learn
+  - jupyter
   - jupyterlab
+  - jupyter_contrib_nbextensions
   - pip:
     - natsort
     - watchdog
     - alpineer>=0.1.10
     - mibi-bin-tools==0.2.14
-    - jupyter_contrib_nbextensions
     - -e .

--- a/release-environment.yml
+++ b/release-environment.yml
@@ -6,11 +6,12 @@ dependencies:
   - pip
   - seaborn
   - scikit-learn
+  - jupyter
   - jupyterlab
+  - jupyter_contrib_nbextensions
   - pip:
     - natsort
     - watchdog
     - alpineer>=0.1.10
     - mibi-bin-tools==0.2.14
-    - jupyter_contrib_nbextensions
     - toffy==0.3.3


### PR DESCRIPTION
**What is the purpose of this PR?**

The `jupyter_contrib_nbextensions` installation was problematic to build with the existing release and prerelease environments on Windows, so this needs to be fixed.

**How did you implement your changes**

Move `jupyter_contrib_nbextensions` to the `conda` section and support `jupyter` download as well.

**Remaining issues**

This is a hotfix, @srivarra has suggested moving to `uv` for the future.