### PR TITLE
Bump `upload-artifact` and `download-artifact` to `v4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         run: pipx run twine check dist/*
 
       - name: Store Wheel and sdist Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distributions
           path: dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download Coverage Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
           path: coverage

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -36,7 +36,7 @@ jobs:
     needs: [test, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: distributions
           path: dist
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: distributions
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           poetry run pytest
 
       - name: Archive Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: |


### PR DESCRIPTION
**What is the purpose of this PR?**

v3 of the artifact upload and download GA have been deprecated per this press release: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/. We need to bump these to v4.

**How did you implement your changes**

Modify each usage of artifact upload/download v3 to v4 in the `.github/workflows` folder.

**Remaining issues**

Potential dependencies with other actions may be broken and need testing.