### PR TITLE
Ensure stitched images are float32

### DIFF
--- a/src/toffy/image_stitching.py
+++ b/src/toffy/image_stitching.py
@@ -238,6 +238,7 @@ def stitch_images(
                 fname = os.path.join(tile_stitched_dir, chan + "_stitched.tiff")
                 stitched = data_utils.stitch_images(image_data, num_cols)
                 current_img = stitched.loc["stitched_image", :, :, chan] / intensity_scale
+                current_img = current_img.astype(np.float32)
                 image_utils.save_image(fname, current_img)
 
         if tma_folders or not tiled:
@@ -266,6 +267,7 @@ def stitch_images(
             fname = os.path.join(stitched_subdir, chan + "_stitched.tiff")
             stitched = data_utils.stitch_images(image_data, num_cols)
             current_img = stitched.loc["stitched_image", :, :, chan] / intensity_scale
+            current_img = current_img.astype(np.float32)
             image_utils.save_image(fname, current_img)
 
 

--- a/tests/image_stitching_test.py
+++ b/tests/image_stitching_test.py
@@ -217,6 +217,7 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir, img_size
                     assert tiled_data.shape == (1, 20 * img_scale, 30 * img_scale, 1)
                 else:
                     assert tiled_data.shape == (1, 20 * img_scale, 20 * img_scale, 1)
+                assert tiled_data.dtype == np.float32
 
                 _, expected_fovs, num_rows, num_cols = expected_tiles[i]
 
@@ -236,6 +237,7 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir, img_size
                 assert sorted(io_utils.list_files(save_dir)) == sorted(stitched_tifs)
                 tma_data = load_utils.load_imgs_from_dir(save_dir, files=["Au_stitched.tiff"])
                 assert tma_data.shape == (1, 20 * img_scale, 10 * img_scale, 1)
+                assert tma_data.dtype == np.float32
 
         # max img size 10 with 3 or 5 acquired fovs
         else:
@@ -246,6 +248,7 @@ def test_stitch_images(mocker, tiled, tile_names, nontiled_fov, subdir, img_size
                 assert data.shape == (1, 30 * img_scale, 20 * img_scale, 1)
             else:
                 assert data.shape == (1, 30 * img_scale, 10 * img_scale, 1)
+            assert data.dtype == np.float32
 
             # data_trim = data[0, ..., ..., 0].values
             base_data = load_utils.load_imgs_from_tree(


### PR DESCRIPTION
**If you haven't already, please read through our [contributing guidelines](https://ark-analysis.readthedocs.io/en/latest/_rtd/contributing.html) before opening your PR**

**What is the purpose of this PR?**

Currently, the image stitching function outputs a float64 tiff file. We would instead like to ensure that the output is float32.

**Remaining issues**

N/A
