### PR TITLE
Use the new `Ba` Rosetta matrix by default

### DIFF
--- a/templates/4a_compensate_image_data.ipynb
+++ b/templates/4a_compensate_image_data.ipynb
@@ -109,7 +109,7 @@
    "outputs": [],
    "source": [
     "# default rosetta matrix provided in toffy\n",
-    "default_matrix_path = os.path.join('..', 'files', 'commercial_rosetta_matrix_v1.csv')\n",
+    "default_matrix_path = os.path.join('..', 'files', 'commercial_rosetta_matrix_v1_Ba.csv')\n",
     "\n",
     "rosetta_testing_dir = 'D:\\\\Rosetta_processing\\\\rosetta_testing'\n",
     "extracted_imgs_dir = 'D:\\\\Extracted_Images'\n",
@@ -436,7 +436,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.11.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
**What is the purpose of this PR?**

The Rosetta workflow should now use the Ba compensated matrix to account for the new workflow.

**How did you implement your changes**

Added the necessary `_Ba.csv` prefix.